### PR TITLE
Fix task linking bug

### DIFF
--- a/src/lib/task-factory.ts
+++ b/src/lib/task-factory.ts
@@ -8,7 +8,7 @@ export class TaskFactory {
 		return {
 			id: this.parseIdFromText(text),
 			summary: this.makeSummary(text),
-			text: text,
+			text: text.trim(),
 			tags: this.parseTags(text),
 			priority: this.parsePriority(text),
 			status: this.parseStatus(status),


### PR DESCRIPTION
This pull request makes a minor improvement to the `TaskFactory` class by ensuring that the `text` property of a task is trimmed of leading and trailing whitespace before being assigned. This helps maintain consistency and prevents issues caused by accidental extra newlines.