### PR TITLE
Fix multiline task bug

### DIFF
--- a/src/lib/task-factory.ts
+++ b/src/lib/task-factory.ts
@@ -8,13 +8,19 @@ export class TaskFactory {
 		return {
 			id: this.parseIdFromText(text),
 			summary: this.makeSummary(text),
-			text: text.trim(),
+			text: this.cleanText(text),
 			tags: this.parseTags(text),
 			priority: this.parsePriority(text),
 			status: this.parseStatus(status),
 			link: rawTask.link?.path,
 			incomingLinks: this.parseIncomingLinks(text),
 		};
+	}
+
+	private cleanText(text: string): string {
+		return text
+			.split('\n')[0]
+			.trim();
 	}
 
 	private parseIdFromText(text: string): string {


### PR DESCRIPTION
This pull request refactors how task text is processed in the `TaskFactory` class. The most important change is that task text is now cleaned to only include the first line and trimmed of whitespace, rather than just being trimmed.

Text processing improvements:

* Updated the `text` property in the returned task object to use a new `cleanText` method, ensuring only the first line of input and trimmed whitespace is included.
* Added a private `cleanText` method to encapsulate the logic for extracting and trimming the first line of task text.