### PR TITLE
Make [title](url) clickable in node summary

### DIFF
--- a/src/components/task-node.tsx
+++ b/src/components/task-node.tsx
@@ -9,6 +9,7 @@ import { Tag } from "./tag";
 import { TaskStatusToggle } from "./task-status";
 import { TaskBackground } from "./task-background";
 import { TaskPriority } from "./task-priority";
+import { renderSummaryLinks } from "../lib/render-summary-links";
 
 export const NODEWIDTH = 250;
 export const NODEHEIGHT = 120;
@@ -40,7 +41,11 @@ export default function TaskNode({ data }: NodeProps<TaskNodeData>) {
 					onStatusChange={setStatus}
 				/>
 				<TaskPriority priority={task.priority} />
-				<span>{task.summary}</span>
+				<span
+					dangerouslySetInnerHTML={{
+						__html: renderSummaryLinks(task.summary),
+					}}
+				/>
 			</div>
 
 			<div className="task-node-content">

--- a/src/lib/render-summary-links.ts
+++ b/src/lib/render-summary-links.ts
@@ -1,0 +1,13 @@
+// Utility to convert markdown/obsidian links to HTML <a> tags
+export function renderSummaryLinks(summary: string): string {
+  // [text](link) => <a href="link" target="_blank" rel="noopener noreferrer">text</a>
+  const mdLink = /\[([^\]]+)\]\(([^)]+)\)/g;
+  // [[other obsidian file]] => <a href="...">other obsidian file</a>
+  const obsidianLink = /\[\[([^\]]+)\]\]/g;
+
+  return summary
+    .replace(mdLink, (_match, text, link) => `<a href="${link}" target="_blank" rel="noopener noreferrer">${text}</a>`)
+    .replace(obsidianLink, (_match, file) => {
+      return `${file}`;
+    });
+}


### PR DESCRIPTION
This pull request enhances how task summaries are displayed by converting markdown and Obsidian-style links in task summaries to clickable HTML links. The main changes include introducing a new utility function for parsing links and updating the task node component to use this function when rendering summaries.

**Task summary rendering improvements:**

* Added a new utility function `renderSummaryLinks` in `src/lib/render-summary-links.ts` to convert markdown (`[text](link)`) and Obsidian (`[[file]]`) links in task summaries to HTML anchor tags.
* Updated `TaskNode` in `src/components/task-node.tsx` to use `renderSummaryLinks` and render the summary with `dangerouslySetInnerHTML`, enabling clickable links in the UI.
* Imported the new `renderSummaryLinks` utility in `src/components/task-node.tsx`.