### PR TITLE
Fix tag bug

### DIFF
--- a/src/lib/task-factory.ts
+++ b/src/lib/task-factory.ts
@@ -49,7 +49,8 @@ export class TaskFactory {
 	}
 
 	private parseTags(text: string): string[] {
-		const tagRegex = /#([a-zA-Z0-9_-]+)/g;
+		// Tag must be preceded by whitespace or line start, and is any non-whitespace after #
+		const tagRegex = /(?:^|\s)#(\S+)/g;
 		const tags = Array.from(text.matchAll(tagRegex)).map((m) => m[1]);
 		return tags;
 	}


### PR DESCRIPTION
Closes #64 
This pull request updates the tag parsing logic in the `TaskFactory` class to improve how tags are detected in text. The new regular expression ensures that tags are only matched when preceded by whitespace or the start of a line, and allows tags to include any non-whitespace characters after the `#`.

- Improved tag parsing in `TaskFactory` by updating the regular expression in the `parseTags` method to only match tags preceded by whitespace or the start of a line, and to allow any non-whitespace characters after `#`.