### PR TITLE
Add status filter

### DIFF
--- a/src/components/gui-overlay.tsx
+++ b/src/components/gui-overlay.tsx
@@ -1,25 +1,48 @@
-import React from "react";
-import TagSelect from "./tag-select";
+import MultiSelect from "./multi-select";
+import { TaskStatus } from "src/types/task";
 
-export default function GuiOverlay(props: {
+interface GuiOverlayProps {
 	allTags: string[];
 	selectedTags: string[];
 	setSelectedTags: (tags: string[]) => void;
 	reloadTasks: () => void;
-}) {
-	const { allTags, selectedTags, setSelectedTags } = props;
+	allStatuses: TaskStatus[];
+	selectedStatuses: TaskStatus[];
+	setSelectedStatuses: (statuses: TaskStatus[]) => void;
+}
+
+export default function GuiOverlay(props: GuiOverlayProps) {
+	const {
+		allTags,
+		selectedTags,
+		setSelectedTags,
+		reloadTasks,
+		allStatuses,
+		selectedStatuses,
+		setSelectedStatuses,
+	} = props;
+
 	return (
 		<>
 			<div className="gui-overlay-tag-select">
-				<TagSelect
-					allTags={allTags}
-					selectedTags={selectedTags}
-					setSelectedTags={setSelectedTags}
+				<MultiSelect
+					options={allTags}
+					selected={selectedTags}
+					setSelected={setSelectedTags}
+					placeholder="Filter by tags..."
+				/>
+			</div>
+			<div className="gui-overlay-status-select">
+				<MultiSelect
+					options={allStatuses}
+					selected={selectedStatuses}
+					setSelected={setSelectedStatuses}
+					placeholder="Filter by status..."
 				/>
 			</div>
 			<div className="gui-overlay-bottom">
 				<button
-					onClick={props.reloadTasks}
+					onClick={reloadTasks}
 					className="gui-overlay-reload-button"
 				>
 					Reload Tasks

--- a/src/components/multi-select.tsx
+++ b/src/components/multi-select.tsx
@@ -1,0 +1,82 @@
+import Select, { MultiValue } from "react-select";
+
+interface MultiSelectProps<T extends string> {
+	options: T[];
+	selected: T[];
+	setSelected: (selected: T[]) => void;
+	placeholder?: string;
+}
+
+type OptionType = { value: string; label: string };
+
+export default function MultiSelect<T extends string>({
+	options,
+	selected,
+	setSelected,
+	placeholder = "Select...",
+}: MultiSelectProps<T>) {
+	return (
+		<Select
+			isMulti
+			options={options.map((o) => ({ value: o, label: o }))}
+			value={selected.map((o) => ({ value: o, label: o }))}
+			onChange={(opts: MultiValue<OptionType>) =>
+				setSelected(opts.map((o) => o.value as T))
+			}
+			placeholder={placeholder}
+			styles={{
+				menu: (base) => ({
+					...base,
+					zIndex: 9999,
+					background: "var(--background-secondary)",
+					color: "var(--text-normal)",
+					border: "1px solid var(--background-modifier-border)",
+				}),
+				control: (base, state) => ({
+					...base,
+					background: "var(--background-primary)",
+					color: "var(--text-normal)",
+					borderColor: "var(--background-modifier-border)",
+					boxShadow: state.isFocused
+						? "0 0 0 1px var(--interactive-accent)"
+						: base.boxShadow,
+					"&:hover": {
+						borderColor: "var(--interactive-accent)",
+					},
+				}),
+				option: (base, state) => ({
+					...base,
+					background: state.isFocused
+						? "var(--background-modifier-hover)"
+						: "var(--background-secondary)",
+					color: "var(--text-normal)",
+				}),
+				multiValue: (base) => ({
+					...base,
+					background: "var(--background-modifier-active)",
+					color: "var(--text-normal)",
+				}),
+				multiValueLabel: (base) => ({
+					...base,
+					color: "var(--text-normal)",
+				}),
+				multiValueRemove: (base) => ({
+					...base,
+					color: "var(--text-faint)",
+					":hover": {
+						background: "var(--background-modifier-hover)",
+						color: "var(--text-normal)",
+					},
+				}),
+				placeholder: (base) => ({
+					...base,
+					color: "var(--text-faint)",
+				}),
+				input: (base) => ({
+					...base,
+					color: "var(--text-normal)",
+				}),
+			}}
+		/>
+	);
+}

--- a/styles.css
+++ b/styles.css
@@ -562,6 +562,14 @@ If your plugin does not need CSS, delete this file.
   min-width: 220px;
 }
 
+.gui-overlay-status-select {
+  position: absolute;
+  top: 80px;
+  right: 32px;
+  z-index: 30;
+  min-width: 220px;
+}
+
 .gui-overlay-reload-button {
   padding: 8px 20px;
   border-radius: 6px;


### PR DESCRIPTION
Closes #67 
This pull request adds support for filtering tasks by status in addition to tags in the task map graph view. It introduces a new reusable `MultiSelect` component, updates the overlay UI to allow selecting multiple statuses, and ensures that both tag and status filters are applied when displaying tasks. Styling for the new status filter UI is also included.

**Task filtering enhancements:**
- Added status-based filtering to the task map graph view, allowing users to filter tasks by both tags and status using the `selectedStatuses` state and updating the filtering logic in `getFilteredNodeIds` and related hooks (`src/views/TaskMapGraphView.tsx`). [[1]](diffhunk://#diff-1e458e6249593aae810c69389c5dca25786355f901fe56415445ceef0c630ec9R26-R29) [[2]](diffhunk://#diff-1e458e6249593aae810c69389c5dca25786355f901fe56415445ceef0c630ec9R38-R40) [[3]](diffhunk://#diff-1e458e6249593aae810c69389c5dca25786355f901fe56415445ceef0c630ec9L65-R86) [[4]](diffhunk://#diff-1e458e6249593aae810c69389c5dca25786355f901fe56415445ceef0c630ec9L84-R118)
- Updated the `GuiOverlay` component to accept and handle status filtering props, and replaced the tag selection dropdown with the new `MultiSelect` component for both tags and statuses (`src/components/gui-overlay.tsx`). [[1]](diffhunk://#diff-a1baef518a8682ff30aa3652c8af304e37036da0bb4524809ec73e5349cc0b48L1-R45) [[2]](diffhunk://#diff-1e458e6249593aae810c69389c5dca25786355f901fe56415445ceef0c630ec9R206-R208)

**Component and UI improvements:**
- Introduced a new reusable `MultiSelect` component based on `react-select`, supporting multi-selection and custom styling to match the application's theme (`src/components/multi-select.tsx`).
- Added CSS for the new status filter dropdown to position and style it appropriately in the overlay (`styles.css`).