### PR TITLE
fix: fix regex for node summary

### DIFF
--- a/src/lib/task-factory.ts
+++ b/src/lib/task-factory.ts
@@ -77,7 +77,7 @@ export class TaskFactory {
 
 	private makeSummary(text: string): string {
 		return text
-			.replace(/#[a-zA-Z0-9_-]+/g, "")
+			.replace(/(?:^|\s)#\S+/g, "")
 			.replace(/([\p{Extended_Pictographic}]+)(\s*[#a-zA-Z0-9_-]+)?/gu, "")
 			.replace(/([\p{Extended_Pictographic}]+)/gu, "")
 			.trim();


### PR DESCRIPTION
This pull request refines the logic for generating task summaries in the `TaskFactory` class. The main change is an improvement to the regular expression used for removing hashtags from text, making the summary cleaner and more accurate.

Summary logic improvements:

* Updated the regular expression in the `makeSummary` method of `TaskFactory` to more accurately remove hashtags, ensuring that hashtags are removed only when they appear at the start of a string or after whitespace. (`src/lib/task-factory.ts`)