### PR TITLE
fix: change visual order of dropdown menus

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -558,7 +558,7 @@ If your plugin does not need CSS, delete this file.
   position: absolute;
   top: 24px;
   right: 32px;
-  z-index: 30;
+  z-index: 35;
   min-width: 220px;
 }
 


### PR DESCRIPTION
This pull request makes a minor adjustment to the CSS styling by increasing the `z-index` value for a positioned element, which will ensure it appears above other elements with lower `z-index` values.

* Increased the `z-index` from 30 to 35 for the absolutely positioned element in `styles.css` to improve layering and visibility.