### PR TITLE
chore: renovate update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,10 @@
 		{
 			"matchManagers": ["github-actions"],
 			"labels": ["semver-noimpact"]
+		},
+		{
+			"matchDepTypes": ["dependencies"],
+			"labels": ["semver-patch"]
 		}
 	]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,17 @@
 	"extends": [
 		"config:recommended"
 	],
-	"baseBranch": "develop"
+	"baseBranch": "main",
+	"automerge": true,
+	"automergeType": "pr",
+	"packageRules": [
+		{
+			"matchDepTypes": ["devDependencies"],
+			"labels": ["semver-noimpact"]
+		},
+		{
+			"matchManagers": ["github-actions"],
+			"labels": ["semver-noimpact"]
+		}
+	]
 }


### PR DESCRIPTION
This pull request updates the `renovate.json` configuration to improve the automation and labeling of dependency updates. The changes set the default branch to `main`, enable automatic merging of pull requests, and add rules for labeling updates based on dependency type.

Configuration improvements:

* Changed the `baseBranch` from `develop` to `main` to align Renovate with the current primary branch.
* Enabled automatic merging of pull requests with `"automerge": true` and set the merge type to `"pr"`.

Dependency update labeling:

* Added `packageRules` to automatically apply labels: `"semver-noimpact"` for devDependencies and GitHub Actions updates, and `"semver-patch"` for regular dependencies.