### PR TITLE
fix: change dataview dependency info message

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -214,3 +214,46 @@ export function createEdgesFromTasks(tasks: Task[]): TaskEdge[] {
   });
   return edges;
 }
+
+/**
+ * Check if the Dataview plugin is installed and enabled
+ * @param app Obsidian App instance
+ * @returns object with isInstalled, isEnabled, and getMessage() function
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function checkDataviewPlugin(app: any) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const plugins = (app as any).plugins;
+
+  // Check if plugin is installed (available in plugins list)
+  const installedPlugins = plugins?.manifests || {};
+  const isInstalled = "dataview" in installedPlugins;
+
+  // Check if plugin is enabled (in enabledPlugins set)
+  const isEnabled = plugins?.enabledPlugins?.has("dataview") || false;
+
+  // Check if plugin is actually loaded (has API available)
+  const dataviewPlugin = plugins?.plugins?.["dataview"];
+  const isLoaded = !!dataviewPlugin;
+
+  const getMessage = () => {
+    if (!isInstalled) {
+      return "Dataview plugin is not installed. Please install the Dataview plugin from Community Plugins to use Tasks Map.";
+    }
+    if (!isEnabled) {
+      return "Dataview plugin is installed but not enabled. Please enable the Dataview plugin in Settings > Community Plugins to use Tasks Map.";
+    }
+    if (!isLoaded) {
+      return "Dataview plugin is enabled but not loaded properly. Please restart Obsidian or reload the Dataview plugin.";
+    }
+    return null;
+  };
+
+  return {
+    isInstalled,
+    isEnabled,
+    isLoaded,
+    isReady: isInstalled && isEnabled && isLoaded,
+    getMessage,
+  };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,10 @@
-import { WorkspaceLeaf, Plugin, Notice } from "obsidian";
+import { WorkspaceLeaf, Plugin } from "obsidian";
 
 import TaskMapGraphItemView, { VIEW_TYPE } from "./views/TaskMapGraphItemView";
 
 export default class TasksMapPlugin extends Plugin {
   async onload() {
-    if (!this.checkDataviewPlugin()) {
-      return;
-    }
-
+    // Always register the view - it will handle the Dataview check internally
     this.registerView(
       VIEW_TYPE,
       (leaf: WorkspaceLeaf) => new TaskMapGraphItemView(leaf)
@@ -20,29 +17,6 @@ export default class TasksMapPlugin extends Plugin {
         this.activateViewInMainArea();
       },
     });
-  }
-
-  private checkDataviewPlugin(): boolean {
-    const plugins = (this.app as any).plugins; // eslint-disable-line @typescript-eslint/no-explicit-any
-    const dataviewPlugin = plugins?.plugins?.["dataview"];
-
-    if (!dataviewPlugin) {
-      new Notice(
-        "Tasks Map: Dataview plugin is not installed. Please install and enable the Dataview plugin.",
-        10000
-      );
-      return false;
-    }
-
-    if (!plugins.enabledPlugins?.has("dataview")) {
-      new Notice(
-        "Tasks Map: Dataview plugin is installed but not enabled. Please enable the Dataview plugin.",
-        10000
-      );
-      return false;
-    }
-
-    return true;
   }
 
   async activateViewInMainArea() {

--- a/src/views/TaskMapGraphItemView.tsx
+++ b/src/views/TaskMapGraphItemView.tsx
@@ -3,6 +3,7 @@ import { createRoot, Root } from "react-dom/client";
 import { ReactFlowProvider } from "reactflow";
 import { AppContext } from "src/contexts/context";
 import TaskMapGraphView from "./TaskMapGraphView";
+import { checkDataviewPlugin } from "../lib/utils";
 
 export const VIEW_TYPE = "tasks-map-graph-view";
 
@@ -22,14 +23,39 @@ export default class TaskMapGraphItemView extends ItemView {
   }
 
   async onOpen() {
+    const dataviewCheck = checkDataviewPlugin(this.app);
+
     this.root = createRoot(this.containerEl.children[1]);
-    this.root.render(
-      <AppContext.Provider value={this.app}>
-        <ReactFlowProvider>
-          <TaskMapGraphView />
-        </ReactFlowProvider>
-      </AppContext.Provider>
-    );
+
+    if (dataviewCheck.isReady) {
+      this.root.render(
+        <AppContext.Provider value={this.app}>
+          <ReactFlowProvider>
+            <TaskMapGraphView />
+          </ReactFlowProvider>
+        </AppContext.Provider>
+      );
+    } else {
+      this.root.render(
+        <div
+          style={{
+            padding: "20px",
+            textAlign: "center",
+            color: "var(--text-muted)",
+            fontSize: "14px",
+          }}
+        >
+          <h3 style={{ color: "var(--text-normal)", marginBottom: "10px" }}>
+            Tasks Map requires the Dataview plugin to be installed and enabled.
+          </h3>
+          <p style={{ marginBottom: "15px" }}>{dataviewCheck.getMessage()}</p>
+          <p style={{ fontSize: "12px" }}>
+            Visit the Community Plugins section in Settings to install or enable
+            Dataview.
+          </p>
+        </div>
+      );
+    }
   }
 
   async onClose() {


### PR DESCRIPTION
This PR changes the way it hints at Dataview not being installed.

When not installed.
<img width="1488" height="244" alt="image" src="https://github.com/user-attachments/assets/84dce7ce-36d1-44a0-9701-9b9bce97fd9f" />


When not enabled.
<img width="1734" height="246" alt="image" src="https://github.com/user-attachments/assets/2c138aff-2de9-44dd-8556-eaf46b67e10c" />
