### PR TITLE
fix: move styles and prevent regressions

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -54,6 +54,14 @@ export default defineConfig([
             "react/jsx-uses-react": "error",
             "react/jsx-uses-vars": "error",
             "@typescript-eslint/no-explicit-any": "error",
+            "react/forbid-dom-props": ["error", {
+                "forbid": [
+                    {
+                        "propName": "style",
+                        "message": "Inline styles are not allowed. Use CSS classes in global.css instead."
+                    }
+                ]
+            }],
         },
     }
 ]);

--- a/global.css
+++ b/global.css
@@ -266,3 +266,52 @@ If your plugin does not need CSS, delete this file.
   border: 1px solid var(--tasks-map-color-red);
   color: var(--text-error);
 }
+
+/* Centered Message Container Styles */
+.tasks-map-centered-message-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  width: 100%;
+}
+
+.tasks-map-centered-message-content {
+  background: var(--background-secondary);
+  padding: 24px;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(var(--tasks-map-color-black-rgb), 0.15);
+  max-width: 600px;
+  text-align: center;
+}
+
+.tasks-map-message-icon {
+  font-size: 48px;
+  margin-bottom: 16px;
+  color: var(--text-warning);
+}
+
+.tasks-map-message-title {
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 8px;
+  color: var(--text-normal);
+  white-space: nowrap;
+}
+
+.tasks-map-message-description {
+  font-size: 14px;
+  color: var(--text-muted);
+  margin-bottom: 16px;
+  line-height: 1.5;
+}
+
+.tasks-map-message-link {
+  color: var(--text-accent);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.tasks-map-message-link:hover {
+  text-decoration: underline;
+}

--- a/src/views/TaskMapGraphItemView.tsx
+++ b/src/views/TaskMapGraphItemView.tsx
@@ -37,22 +37,21 @@ export default class TaskMapGraphItemView extends ItemView {
       );
     } else {
       this.root.render(
-        <div
-          style={{
-            padding: "20px",
-            textAlign: "center",
-            color: "var(--text-muted)",
-            fontSize: "14px",
-          }}
-        >
-          <h3 style={{ color: "var(--text-normal)", marginBottom: "10px" }}>
-            Tasks Map requires the Dataview plugin to be installed and enabled.
-          </h3>
-          <p style={{ marginBottom: "15px" }}>{dataviewCheck.getMessage()}</p>
-          <p style={{ fontSize: "12px" }}>
-            Visit the Community Plugins section in Settings to install or enable
-            Dataview.
-          </p>
+        <div className="tasks-map-centered-message-container">
+          <div className="tasks-map-centered-message-content">
+            <div className="tasks-map-message-icon">⚠️</div>
+            <h3 className="tasks-map-message-title">
+              Tasks Map requires the Dataview plugin to be installed and
+              enabled.
+            </h3>
+            <p className="tasks-map-message-description">
+              {dataviewCheck.getMessage()}
+            </p>
+            <p className="tasks-map-message-description">
+              Visit the Community Plugins section in Settings to install or
+              enable Dataview.
+            </p>
+          </div>
         </div>
       );
     }


### PR DESCRIPTION
This pull request improves code quality and user experience by enforcing a new linting rule against inline styles in React components and refactoring a warning message to use new CSS classes instead of inline styles. Additionally, it introduces new CSS classes to style centered messages consistently across the app.

**Linting and Code Quality:**

* Added a new ESLint rule (`react/forbid-dom-props`) to disallow the use of the `style` prop in React components, encouraging the use of CSS classes defined in `global.css` instead.

**UI Refactoring and Styling:**

* Replaced inline styles in the Dataview plugin warning message within `TaskMapGraphItemView.tsx` with semantic CSS classes for better maintainability and consistency.
* Added new CSS classes in `global.css` to support centered message containers and content, including styles for icons, titles, descriptions, and links.

<img width="1332" height="620" alt="image" src="https://github.com/user-attachments/assets/606ef658-4402-456a-adbf-a759c6425451" />
