### PR TITLE
fix: stop showing non-tasks

### DIFF
--- a/src/lib/task-factory.ts
+++ b/src/lib/task-factory.ts
@@ -21,6 +21,12 @@ export class TaskFactory {
     };
   }
 
+  public isEmptyTask(task: Task): boolean {
+    // A task is considered empty if its summary (which strips tags, IDs, emojis, etc.)
+    // is empty or whitespace-only
+    return task.summary.trim().length === 0;
+  }
+
   private cleanText(text: string): string {
     return text.split("\n")[0].trim();
   }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -391,7 +391,10 @@ export function getAllDataviewTasks(app: any): Task[] {
     }
   }
   const factory = new TaskFactory();
-  return tasks.map((rawTask: any) => factory.parse(rawTask)); // eslint-disable-line @typescript-eslint/no-explicit-any
+  const parsedTasks = tasks.map((rawTask: any) => factory.parse(rawTask)); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+  // Filter out empty tasks (tasks with no meaningful content after stripping metadata)
+  return parsedTasks.filter((task) => !factory.isEmptyTask(task));
 }
 
 export function createNodesFromTasks(

--- a/test/fixture/Simple tasks.md
+++ b/test/fixture/Simple tasks.md
@@ -5,3 +5,8 @@
 - [ ] See what went well #example #easy ⛔ 67zv0n 🆔 3quyej
 - [ ] Note improvements #example #documentation ⛔ 3quyej 🆔 ldri05
 - [ ] Extra final task with a really long description here ⛔ ldri05 ⛔ 3quyej
+
+Non task:
+- [ ] 
+
+Some arbitrary file contents.


### PR DESCRIPTION
Closes #148

It is not uncommon to have empty tasks - e.g. in templates - that are just `- [ ]` It's better to ignore these as they don't add value. Hence releasing this as a #patch.