### PR TITLE
feat: Support inline code formatting in task titles

### DIFF
--- a/global.css
+++ b/global.css
@@ -467,6 +467,16 @@ If your plugin does not need CSS, delete this file.
   flex: 1;
 }
 
+/* Inline code styling for task summaries */
+.tasks-map-inline-code {
+  font-family: var(--font-monospace);
+  font-size: 0.9em;
+  padding: 2px 4px;
+  border-radius: 4px;
+  background-color: var(--code-background);
+  color: var(--code-normal);
+}
+
 /* GUI Overlay Styles */
 .tasks-map-gui-overlay-bottom {
   position: absolute;

--- a/src/hooks/use-summary-renderer.ts
+++ b/src/hooks/use-summary-renderer.ts
@@ -14,7 +14,8 @@ export function useSummaryRenderer(summary: string) {
 }
 
 function renderSummaryWithLinks(summary: string, container: HTMLElement) {
-  const parts = summary.split(/(\[[^\]]+\]\([^)]+\)|\[\[[^\]]+\]\])/g);
+  // Split by links and inline code blocks
+  const parts = summary.split(/(\[[^\]]+\]\([^)]+\)|\[\[[^\]]+\]\]|`[^`]+`)/g);
 
   parts.forEach((part) => {
     const mdLinkMatch = part.match(/\[([^\]]+)\]\(([^)]+)\)/);
@@ -38,6 +39,17 @@ function renderSummaryWithLinks(summary: string, container: HTMLElement) {
       container.createEl("a", {
         text: file,
         href: `obsidian://open?path=${encodeURIComponent(file.replace(/\s/g, " "))}`,
+      });
+      return;
+    }
+
+    // Check if it's inline code `text`
+    const inlineCodeMatch = part.match(/^`([^`]+)`$/);
+    if (inlineCodeMatch) {
+      const [, code] = inlineCodeMatch;
+      container.createEl("code", {
+        text: code,
+        cls: "tasks-map-inline-code",
       });
       return;
     }


### PR DESCRIPTION
## Summary

Adds support for rendering inline code (backtick-delimited text) in task titles, similar to GitHub's issue/PR title formatting.

## Changes

- Extended `useSummaryRenderer` hook to parse and render backtick-delimited text as `<code>` elements
- Added CSS styling for inline code using Obsidian's native code styling variables

## Example

A task with title:
```
My epic task for `highlighted` text here
```

Will now render with "highlighted" styled as inline code.

closes #166 