### PR TITLE
chore: codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @NicoKNL


### PR DESCRIPTION
A recent PR made it clear that branch protection wasn't set very well. PRs now explicitly require approval from 1 reviewer from the codeowners.