### PR TITLE
feat: use deploy key for release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,6 +86,7 @@ jobs:
           fetch-depth: 0
           # Ensure we're on the main branch after the PR is merged
           ref: ${{ github.event.pull_request.base.ref }}
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Get PR labels
         id: check-labels


### PR DESCRIPTION
## Changes
Modified the release workflow to use the DEPLOY_KEY secret for authentication when pushing release commits and tags. This allows the workflow to bypass branch protection rules.

## Details
Added ssh-key: ${{ secrets.DEPLOY_KEY }} to the checkout action in the release job
This configures git to use SSH authentication with the deploy key for all subsequent git operations
The deploy key will bypass branch protection, allowing the automated release process to push directly to the main branch

### Prerequisites
Requires the DEPLOY_KEY secret to be configured in repository settings with write access.

ℹ️ Releasing as minor to release a previously unreleased feature.
