### PR TITLE
feat: internationalisation: `en`, `nl`, `zh-CN`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,25 +10,25 @@
 
 ---
 
-
 **Tasks Map** is a minimal Obsidian plugin that visualizes your `- [ ] tasks` as an interactive graph. Each task is represented as a node, with edges showing relationships based on special emoji/link syntax in your task text as implemented in the popular Tasks plugin.
 
 ## Pre-requisites
 
--   **Required:** You must have both the [Dataview](https://github.com/blacksmithgu/obsidian-dataview) plugin and the [Tasks](https://github.com/obsidian-tasks-group/obsidian-tasks) plugin installed and enabled in your vault.
+- **Required:** You must have both the [Dataview](https://github.com/blacksmithgu/obsidian-dataview) plugin and the [Tasks](https://github.com/obsidian-tasks-group/obsidian-tasks) plugin installed and enabled in your vault.
 
 ## Features
 
--   **Graph Visualization:** See all your Dataview tasks as draggable nodes in a React Flow graph.
--   **Custom Nodes:** Each node displays task summary, tags, priority emoji, and completion status (color-coded).
--   **Task Relationships:** Edges are created based on special emoji/link syntax (🆔 for outgoing, ⛔ for incoming, with hashes).
--   **Edge Management:** Select and delete edges (removes the hash from both tasks/files).
--   **Tag Filtering:** Filter visible tasks by tag using a multi-select dropdown overlay.
--   **Quick Navigation:** Open the linked file for any task directly from the node.
--   **Task Completion:** Mark tasks as completed/incomplete directly from the graph.
--   **UI Overlays:** Modern overlays for tag filtering and reloading tasks.
--   **Priority & Emoji Support:** Priority emoji (🔺, ⏫, 🔼, 🔽, ⏬) and robust emoji rendering.
--   **Automatic Layout:** Uses dagre for clean, readable graph layouts.
+- **Graph Visualization:** See all your Dataview tasks as draggable nodes in a React Flow graph.
+- **Custom Nodes:** Each node displays task summary, tags, priority emoji, and completion status (color-coded).
+- **Task Relationships:** Edges are created based on special emoji/link syntax (🆔 for outgoing, ⛔ for incoming, with hashes).
+- **Edge Management:** Select and delete edges (removes the hash from both tasks/files).
+- **Tag Filtering:** Filter visible tasks by tag using a multi-select dropdown overlay.
+- **Quick Navigation:** Open the linked file for any task directly from the node.
+- **Task Completion:** Mark tasks as completed/incomplete directly from the graph.
+- **UI Overlays:** Modern overlays for tag filtering and reloading tasks.
+- **Priority & Emoji Support:** Priority emoji (🔺, ⏫, 🔼, 🔽, ⏬) and robust emoji rendering.
+- **Automatic Layout:** Uses dagre for clean, readable graph layouts.
+- **Internationalization:** Support for multiple languages (English, Dutch, Simplified Chinese) with easy language switching in settings.
 
 ### Examples
 
@@ -44,39 +44,39 @@ Install through the Obsidian plugin manager: https://obsidian.md/plugins?id=task
 
 1. **Clone or Download:** Place the plugin folder in your vault's `.obsidian/plugins/tasks-map/` directory.
 2. **Install Dependencies:**
-    ```sh
-    npm install
-    ```
+   ```sh
+   npm install
+   ```
 3. **Build the Plugin:**
-    ```sh
-    npm run build
-    ```
+   ```sh
+   npm run build
+   ```
 4. **Enable in Obsidian:**
-    - Open Obsidian settings → Community plugins → Enable "Tasks Map".
+   - Open Obsidian settings → Community plugins → Enable "Tasks Map".
 
 ## Usage
 
--   Open the "Tasks Map" view from the ribbon or command palette.
--   Drag nodes to rearrange tasks visually.
--   Click the checkmark to mark a task as completed/incomplete.
--   Click the link icon to open the task's file.
--   Select and delete edges to remove task relationships.
--   Use the tag filter overlay to focus your view.
+- Open the "Tasks Map" view from the ribbon or command palette.
+- Drag nodes to rearrange tasks visually.
+- Click the checkmark to mark a task as completed/incomplete.
+- Click the link icon to open the task's file.
+- Select and delete edges to remove task relationships.
+- Use the tag filter overlay to focus your view.
 
 ## Development
 
--   **Dev Mode:**
-    ```sh
-    npm run dev
-    ```
--   **Build:**
-    ```sh
-    npm run build
-    ```
--   **Lint:**
-    ```sh
-    npm run lint
-    ```
+- **Dev Mode:**
+  ```sh
+  npm run dev
+  ```
+- **Build:**
+  ```sh
+  npm run build
+  ```
+- **Lint:**
+  ```sh
+  npm run lint
+  ```
 
 ## Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "@dagrejs/dagre": "^1.1.5",
+                "i18next": "^25.7.4",
                 "lucide-react": "^0.562.0",
                 "react": "^19.1.0",
                 "react-dom": "^19.1.0",
@@ -77,7 +78,6 @@
             "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.3",
@@ -510,9 +510,9 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.27.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
-            "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+            "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -1993,7 +1993,8 @@
             "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
             "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@napi-rs/wasm-runtime": {
             "version": "0.2.12",
@@ -2566,7 +2567,6 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.8.tgz",
             "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -2669,7 +2669,6 @@
             "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.53.0",
                 "@typescript-eslint/types": "8.53.0",
@@ -3176,7 +3175,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3616,7 +3614,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.8.9",
                 "caniuse-lite": "^1.0.30001746",
@@ -3970,7 +3967,8 @@
             "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
             "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
@@ -4050,7 +4048,6 @@
             "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
             "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
             "license": "ISC",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -4563,7 +4560,6 @@
             "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -5505,6 +5501,37 @@
                 "node": ">=10.17.0"
             }
         },
+        "node_modules/i18next": {
+            "version": "25.7.4",
+            "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.7.4.tgz",
+            "integrity": "sha512-hRkpEblXXcXSNbw8mBNq9042OEetgyB/ahc/X17uV/khPwzV+uB8RHceHh3qavyrkPJvmXFKXME2Sy1E0KjAfw==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://locize.com"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://locize.com/i18next.html"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.28.4"
+            },
+            "peerDependencies": {
+                "typescript": "^5"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/ignore": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -6150,7 +6177,6 @@
             "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/core": "30.2.0",
                 "@jest/types": "30.2.0",
@@ -7666,7 +7692,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
             "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -7676,7 +7701,6 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
             "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -8447,7 +8471,8 @@
             "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
             "integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/stylis": {
             "version": "4.2.0",
@@ -8574,7 +8599,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -8806,9 +8830,8 @@
             "version": "5.9.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -8983,7 +9006,8 @@
             "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
             "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/walker": {
             "version": "1.0.8",
@@ -9352,7 +9376,6 @@
             "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     },
     "dependencies": {
         "@dagrejs/dagre": "^1.1.5",
+        "i18next": "^25.7.4",
         "lucide-react": "^0.562.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",

--- a/src/components/gui-overlay.tsx
+++ b/src/components/gui-overlay.tsx
@@ -3,6 +3,7 @@ import TagSelect from "./tag-select";
 import { TaskStatus } from "src/types/task";
 import React, { useState } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
+import { t } from "../i18n";
 
 interface GuiOverlayProps {
   allTags: string[];
@@ -56,7 +57,11 @@ export default function GuiOverlay(props: GuiOverlayProps) {
       <button
         className="tasks-map-filter-panel-toggle"
         onClick={toggleMinimized}
-        title={isMinimized ? "Expand filters" : "Minimize filters"}
+        title={
+          isMinimized
+            ? t("filters.expand_filters")
+            : t("filters.minimize_filters")
+        }
       >
         {isMinimized ? <ChevronLeft size={18} /> : <ChevronRight size={12} />}
       </button>
@@ -65,17 +70,21 @@ export default function GuiOverlay(props: GuiOverlayProps) {
         <>
           <div className="tasks-map-filter-section">
             <div className="tasks-map-filter-item">
-              <label className="tasks-map-filter-label">Status</label>
+              <label className="tasks-map-filter-label">
+                {t("filters.status")}
+              </label>
               <MultiSelect
                 options={allStatuses}
                 selected={selectedStatuses}
                 setSelected={setSelectedStatuses}
-                placeholder="Filter by status..."
+                placeholder={t("filters.filter_by_status")}
               />
             </div>
 
             <div className="tasks-map-filter-item">
-              <label className="tasks-map-filter-label">Include labels</label>
+              <label className="tasks-map-filter-label">
+                {t("filters.include_labels")}
+              </label>
               <TagSelect
                 allTags={allTags}
                 selectedTags={selectedTags}
@@ -84,7 +93,9 @@ export default function GuiOverlay(props: GuiOverlayProps) {
             </div>
 
             <div className="tasks-map-filter-item">
-              <label className="tasks-map-filter-label">Exclude labels</label>
+              <label className="tasks-map-filter-label">
+                {t("filters.exclude_labels")}
+              </label>
               <TagSelect
                 allTags={allTags}
                 selectedTags={excludedTags}
@@ -93,12 +104,14 @@ export default function GuiOverlay(props: GuiOverlayProps) {
             </div>
 
             <div className="tasks-map-filter-item">
-              <label className="tasks-map-filter-label">Files / Folders</label>
+              <label className="tasks-map-filter-label">
+                {t("filters.files_folders")}
+              </label>
               <MultiSelect
                 options={allFiles}
                 selected={selectedFiles}
                 setSelected={setSelectedFiles}
-                placeholder="Filter by file or folder..."
+                placeholder={t("filters.filter_by_file")}
               />
             </div>
 
@@ -112,7 +125,7 @@ export default function GuiOverlay(props: GuiOverlayProps) {
                     className="tasks-map-gui-overlay-checkbox-input"
                   />
                   <span className="tasks-map-gui-overlay-checkbox-text">
-                    Hide tags on nodes
+                    {t("filters.hide_tags_on_nodes")}
                   </span>
                 </label>
               </div>
@@ -125,7 +138,7 @@ export default function GuiOverlay(props: GuiOverlayProps) {
               onClick={reloadTasks}
               className="tasks-map-gui-overlay-reload-button"
             >
-              Reload tasks
+              {t("filters.reload_tasks")}
             </button>
           </div>
         </>

--- a/src/components/multi-select.tsx
+++ b/src/components/multi-select.tsx
@@ -1,4 +1,5 @@
 import Select, { MultiValue } from "react-select";
+import { t } from "../i18n";
 
 interface MultiSelectProps<T extends string> {
   options: T[];
@@ -13,7 +14,7 @@ export default function MultiSelect<T extends string>({
   options,
   selected,
   setSelected,
-  placeholder = "Select...",
+  placeholder = t("multiselect.select"),
 }: MultiSelectProps<T>) {
   return (
     <Select

--- a/src/components/tag-select.tsx
+++ b/src/components/tag-select.tsx
@@ -1,7 +1,7 @@
 import Select, { MultiValue } from "react-select";
+import { t } from "../i18n";
 
 export const NO_TAGS_VALUE = "__NO_TAGS__";
-const NO_TAGS_LABEL = "No tags";
 
 interface TagSelectProps {
   allTags: string[];
@@ -17,7 +17,7 @@ export default function TagSelect({
   setSelectedTags,
 }: TagSelectProps) {
   const options: TagOption[] = [
-    { value: NO_TAGS_VALUE, label: NO_TAGS_LABEL },
+    { value: NO_TAGS_VALUE, label: t("multiselect.no_tags") },
     ...allTags.map((tag) => ({ value: tag, label: tag })),
   ];
 
@@ -27,12 +27,12 @@ export default function TagSelect({
       options={options}
       value={selectedTags.map((tag) => ({
         value: tag,
-        label: tag === NO_TAGS_VALUE ? NO_TAGS_LABEL : tag,
+        label: tag === NO_TAGS_VALUE ? t("multiselect.no_tags") : tag,
       }))}
       onChange={(opts: MultiValue<TagOption>) =>
         setSelectedTags(opts.map((o) => o.value))
       }
-      placeholder="Filter by tags..."
+      placeholder={t("filters.filter_by_status")}
       styles={{
         menu: (base) => ({
           ...base,

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,39 @@
+import i18next from "i18next";
+import en from "./locales/en.json";
+import nl from "./locales/nl.json";
+import zh from "./locales/zh-CN.json";
+
+export type Language = "en" | "nl" | "zh-CN";
+
+export const SUPPORTED_LANGUAGES: { value: Language; label: string }[] = [
+  { value: "en", label: "English" },
+  { value: "nl", label: "Nederlands (Dutch)" },
+  { value: "zh-CN", label: "简体中文 (Simplified Chinese)" },
+];
+
+const resources = {
+  en: { translation: en },
+  nl: { translation: nl },
+  "zh-CN": { translation: zh },
+};
+
+export async function initI18n(language: Language = "en") {
+  await i18next.init({
+    lng: language,
+    fallbackLng: "en",
+    resources,
+    interpolation: {
+      escapeValue: false, // React already escapes values
+    },
+  });
+}
+
+export function changeLanguage(language: Language) {
+  i18next.changeLanguage(language);
+}
+
+export function t(key: string, options?: Record<string, unknown>): string {
+  return i18next.t(key, options);
+}
+
+export default i18next;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,0 +1,82 @@
+{
+  "plugin": {
+    "name": "Tasks Map",
+    "description": "A graph view of your tasks"
+  },
+  "commands": {
+    "open_map_view": "Open map view"
+  },
+  "ribbon": {
+    "open_tasks_map": "Open tasks map view"
+  },
+  "view": {
+    "title": "Tasks map",
+    "dataview_required": "Tasks Map requires the Dataview plugin to be installed and enabled.",
+    "dataview_not_installed": "The Dataview plugin is not currently installed.",
+    "dataview_disabled": "The Dataview plugin is installed but not enabled.",
+    "visit_community_plugins": "Visit the Community Plugins section in Settings to install or enable Dataview."
+  },
+  "settings": {
+    "display_options": "Display Options",
+    "show_task_priorities": "Show task priorities",
+    "show_task_priorities_desc": "Display priority indicators on task nodes",
+    "show_task_tags": "Show task tags",
+    "show_task_tags_desc": "Display tags on task nodes",
+    "layout": "Layout",
+    "layout_direction": "Layout direction",
+    "layout_direction_desc": "Direction for the node layout",
+    "layout_horizontal": "Horizontal",
+    "layout_vertical": "Vertical",
+    "tag_appearance": "Tag Appearance",
+    "tag_color_mode": "Tag color mode",
+    "tag_color_mode_desc": "Choose how tag colors are generated",
+    "tag_color_random": "Random colors (seeded)",
+    "tag_color_static": "Static color for all tags",
+    "color_seed": "Color seed",
+    "color_seed_desc": "Seed value for random color generation (same seed = same colors)",
+    "preview": "Preview",
+    "preview_random_desc": "Example tags with random colors",
+    "preview_static_desc": "Example tags with static color",
+    "static_tag_color": "Static tag color",
+    "static_tag_color_desc": "Color to use for all tags",
+    "simple_task_relations": "Simple Task Relations",
+    "linking_style": "Linking style",
+    "linking_style_desc": "How task dependencies are specified in simple tasks",
+    "linking_csv": "CSV (Tasks plugin default)",
+    "linking_individual": "Individual",
+    "linking_dataview": "Dataview",
+    "linking_individual_title": "Individual Style:",
+    "linking_individual_desc": "Each dependency with its own emoji identifier",
+    "linking_individual_example": "- [ ] My task ⛔ abc123 ⛔ def456 ⛔ ghi789",
+    "linking_dataview_title": "Dataview Style:",
+    "linking_dataview_desc": "Dependencies using Dataview inline field syntax",
+    "linking_dataview_example": "- [ ] My task [[dependsOn:: abc123,def456,ghi789]]",
+    "linking_csv_title": "CSV Style (Tasks plugin default):",
+    "linking_csv_desc": "Multiple dependencies comma-separated",
+    "linking_csv_example": "- [ ] My task ⛔ abc123,def456,ghi789",
+    "advanced_options": "Advanced Options",
+    "debug_visualization": "Debug visualization",
+    "debug_visualization_desc": "Show additional debug information in the graph view",
+    "language": "Language",
+    "language_desc": "Select the language for the plugin interface"
+  },
+  "filters": {
+    "status": "Status",
+    "include_labels": "Include labels",
+    "exclude_labels": "Exclude labels",
+    "files_folders": "Files / Folders",
+    "hide_tags_on_nodes": "Hide tags on nodes",
+    "reload_tasks": "Reload tasks",
+    "expand_filters": "Expand filters",
+    "minimize_filters": "Minimize filters",
+    "filter_by_status": "Filter by status...",
+    "filter_by_file": "Filter by file or folder..."
+  },
+  "multiselect": {
+    "select": "Select...",
+    "no_tags": "No tags"
+  },
+  "errors": {
+    "cannot_create_edges_different_types": "Cannot create edges between different task types (dataview and note-based tasks). Both tasks must be of the same type."
+  }
+}

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1,0 +1,82 @@
+{
+  "plugin": {
+    "name": "Taken Kaart",
+    "description": "Een grafische weergave van je taken"
+  },
+  "commands": {
+    "open_map_view": "Kaartweergave openen"
+  },
+  "ribbon": {
+    "open_tasks_map": "Taken kaartweergave openen"
+  },
+  "view": {
+    "title": "Taken kaart",
+    "dataview_required": "Taken Kaart vereist dat de Dataview-plugin is geïnstalleerd en ingeschakeld.",
+    "dataview_not_installed": "De Dataview-plugin is momenteel niet geïnstalleerd.",
+    "dataview_disabled": "De Dataview-plugin is geïnstalleerd maar niet ingeschakeld.",
+    "visit_community_plugins": "Ga naar het gedeelte Community Plugins in Instellingen om Dataview te installeren of in te schakelen."
+  },
+  "settings": {
+    "display_options": "Weergaveopties",
+    "show_task_priorities": "Taakprioriteiten tonen",
+    "show_task_priorities_desc": "Toon prioriteitsindicatoren op taakknooppunten",
+    "show_task_tags": "Taak tags tonen",
+    "show_task_tags_desc": "Toon tags op taakknooppunten",
+    "layout": "Indeling",
+    "layout_direction": "Indelingsrichting",
+    "layout_direction_desc": "Richting voor de knooppuntindeling",
+    "layout_horizontal": "Horizontaal",
+    "layout_vertical": "Verticaal",
+    "tag_appearance": "Tag Uiterlijk",
+    "tag_color_mode": "Tag kleurmodus",
+    "tag_color_mode_desc": "Kies hoe tagkleuren worden gegenereerd",
+    "tag_color_random": "Willekeurige kleuren (met seed)",
+    "tag_color_static": "Statische kleur voor alle tags",
+    "color_seed": "Kleur seed",
+    "color_seed_desc": "Seed-waarde voor willekeurige kleurgeneratie (dezelfde seed = dezelfde kleuren)",
+    "preview": "Voorbeeld",
+    "preview_random_desc": "Voorbeeldtags met willekeurige kleuren",
+    "preview_static_desc": "Voorbeeldtags met statische kleur",
+    "static_tag_color": "Statische tagkleur",
+    "static_tag_color_desc": "Kleur om te gebruiken voor alle tags",
+    "simple_task_relations": "Eenvoudige Taakrelaties",
+    "linking_style": "Koppelstijl",
+    "linking_style_desc": "Hoe taakafhankelijkheden worden gespecificeerd in eenvoudige taken",
+    "linking_csv": "CSV (Taken plugin standaard)",
+    "linking_individual": "Individueel",
+    "linking_dataview": "Dataview",
+    "linking_individual_title": "Individuele Stijl:",
+    "linking_individual_desc": "Elke afhankelijkheid met zijn eigen emoji-identificatie",
+    "linking_individual_example": "- [ ] Mijn taak ⛔ abc123 ⛔ def456 ⛔ ghi789",
+    "linking_dataview_title": "Dataview Stijl:",
+    "linking_dataview_desc": "Afhankelijkheden met Dataview inline veldsyntax",
+    "linking_dataview_example": "- [ ] Mijn taak [[dependsOn:: abc123,def456,ghi789]]",
+    "linking_csv_title": "CSV Stijl (Taken plugin standaard):",
+    "linking_csv_desc": "Meerdere afhankelijkheden gescheiden door komma's",
+    "linking_csv_example": "- [ ] Mijn taak ⛔ abc123,def456,ghi789",
+    "advanced_options": "Geavanceerde Opties",
+    "debug_visualization": "Debug visualisatie",
+    "debug_visualization_desc": "Toon aanvullende debug-informatie in de grafiekweergave",
+    "language": "Taal",
+    "language_desc": "Selecteer de taal voor de plugin-interface"
+  },
+  "filters": {
+    "status": "Status",
+    "include_labels": "Labels opnemen",
+    "exclude_labels": "Labels uitsluiten",
+    "files_folders": "Bestanden / Mappen",
+    "hide_tags_on_nodes": "Tags op knooppunten verbergen",
+    "reload_tasks": "Taken opnieuw laden",
+    "expand_filters": "Filters uitvouwen",
+    "minimize_filters": "Filters minimaliseren",
+    "filter_by_status": "Filteren op status...",
+    "filter_by_file": "Filteren op bestand of map..."
+  },
+  "multiselect": {
+    "select": "Selecteer...",
+    "no_tags": "Geen tags"
+  },
+  "errors": {
+    "cannot_create_edges_different_types": "Kan geen verbindingen maken tussen verschillende taaktypes (dataview en notitie-gebaseerde taken). Beide taken moeten van hetzelfde type zijn."
+  }
+}

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1,0 +1,82 @@
+{
+  "plugin": {
+    "name": "任务地图",
+    "description": "任务的图形视图"
+  },
+  "commands": {
+    "open_map_view": "打开地图视图"
+  },
+  "ribbon": {
+    "open_tasks_map": "打开任务地图视图"
+  },
+  "view": {
+    "title": "任务地图",
+    "dataview_required": "任务地图需要安装并启用 Dataview 插件。",
+    "dataview_not_installed": "当前未安装 Dataview 插件。",
+    "dataview_disabled": "Dataview 插件已安装但未启用。",
+    "visit_community_plugins": "请访问设置中的社区插件部分以安装或启用 Dataview。"
+  },
+  "settings": {
+    "display_options": "显示选项",
+    "show_task_priorities": "显示任务优先级",
+    "show_task_priorities_desc": "在任务节点上显示优先级指示器",
+    "show_task_tags": "显示任务标签",
+    "show_task_tags_desc": "在任务节点上显示标签",
+    "layout": "布局",
+    "layout_direction": "布局方向",
+    "layout_direction_desc": "节点布局的方向",
+    "layout_horizontal": "水平",
+    "layout_vertical": "垂直",
+    "tag_appearance": "标签外观",
+    "tag_color_mode": "标签颜色模式",
+    "tag_color_mode_desc": "选择如何生成标签颜色",
+    "tag_color_random": "随机颜色（有种子）",
+    "tag_color_static": "所有标签使用静态颜色",
+    "color_seed": "颜色种子",
+    "color_seed_desc": "随机颜色生成的种子值（相同种子 = 相同颜色）",
+    "preview": "预览",
+    "preview_random_desc": "随机颜色的示例标签",
+    "preview_static_desc": "静态颜色的示例标签",
+    "static_tag_color": "静态标签颜色",
+    "static_tag_color_desc": "所有标签使用的颜色",
+    "simple_task_relations": "简单任务关系",
+    "linking_style": "链接样式",
+    "linking_style_desc": "如何在简单任务中指定任务依赖关系",
+    "linking_csv": "CSV（任务插件默认）",
+    "linking_individual": "单独",
+    "linking_dataview": "Dataview",
+    "linking_individual_title": "单独样式：",
+    "linking_individual_desc": "每个依赖项都有自己的表情符号标识符",
+    "linking_individual_example": "- [ ] 我的任务 ⛔ abc123 ⛔ def456 ⛔ ghi789",
+    "linking_dataview_title": "Dataview 样式：",
+    "linking_dataview_desc": "使用 Dataview 内联字段语法的依赖项",
+    "linking_dataview_example": "- [ ] 我的任务 [[dependsOn:: abc123,def456,ghi789]]",
+    "linking_csv_title": "CSV 样式（任务插件默认）：",
+    "linking_csv_desc": "多个依赖项用逗号分隔",
+    "linking_csv_example": "- [ ] 我的任务 ⛔ abc123,def456,ghi789",
+    "advanced_options": "高级选项",
+    "debug_visualization": "调试可视化",
+    "debug_visualization_desc": "在图形视图中显示附加调试信息",
+    "language": "语言",
+    "language_desc": "选择插件界面的语言"
+  },
+  "filters": {
+    "status": "状态",
+    "include_labels": "包含标签",
+    "exclude_labels": "排除标签",
+    "files_folders": "文件 / 文件夹",
+    "hide_tags_on_nodes": "隐藏节点上的标签",
+    "reload_tasks": "重新加载任务",
+    "expand_filters": "展开筛选器",
+    "minimize_filters": "最小化筛选器",
+    "filter_by_status": "按状态筛选...",
+    "filter_by_file": "按文件或文件夹筛选..."
+  },
+  "multiselect": {
+    "select": "选择...",
+    "no_tags": "无标签"
+  },
+  "errors": {
+    "cannot_create_edges_different_types": "无法在不同任务类型（dataview 和基于笔记的任务）之间创建连接。两个任务必须是相同类型。"
+  }
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,6 +6,7 @@ import { BaseTask } from "src/types/base-task";
 import { NODEHEIGHT, NODEWIDTH } from "src/components/task-node";
 import { TaskFactory } from "./task-factory";
 import { Position, Node, Edge } from "reactflow";
+import { t } from "../i18n";
 
 export const statusSymbols = {
   todo: "[ ]",
@@ -983,10 +984,10 @@ export function checkDataviewPlugin(app: any) {
 
   const getMessage = () => {
     if (!isInstalled) {
-      return "Dataview plugin is not installed. Please install the Dataview plugin from Community Plugins to use Tasks Map.";
+      return t("view.dataview_not_installed");
     }
     if (!isEnabled) {
-      return "Dataview plugin is installed but not enabled. Please enable the Dataview plugin in Settings > Community Plugins to use Tasks Map.";
+      return t("view.dataview_disabled");
     }
     if (!isLoaded) {
       return "Dataview plugin is enabled but not loaded properly. Please restart Obsidian or reload the Dataview plugin.";

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { WorkspaceLeaf, Plugin } from "obsidian";
 import TaskMapGraphItemView, { VIEW_TYPE } from "./views/TaskMapGraphItemView";
 import { TasksMapSettings, DEFAULT_SETTINGS } from "./types/settings";
 import { TasksMapSettingTab } from "./settings/settings-tab";
+import { initI18n, changeLanguage, t } from "./i18n";
 
 export default class TasksMapPlugin extends Plugin {
   settings: TasksMapSettings = DEFAULT_SETTINGS;
@@ -10,6 +11,9 @@ export default class TasksMapPlugin extends Plugin {
   async onload() {
     // Load settings
     await this.loadSettings();
+
+    // Initialize i18n with saved language
+    await initI18n(this.settings.language);
 
     // Always register the view - it will handle the Dataview check internally
     this.registerView(
@@ -21,13 +25,13 @@ export default class TasksMapPlugin extends Plugin {
 
     this.addCommand({
       id: "open-tasks-map-view",
-      name: "Open map view",
+      name: t("commands.open_map_view"),
       callback: () => {
         this.activateViewInMainArea();
       },
     });
 
-    this.addRibbonIcon("map", "Open tasks map view", () => {
+    this.addRibbonIcon("map", t("ribbon.open_tasks_map"), () => {
       this.activateViewInMainArea();
     });
   }
@@ -38,6 +42,8 @@ export default class TasksMapPlugin extends Plugin {
 
   async saveSettings() {
     await this.saveData(this.settings);
+    // Update language when settings change
+    changeLanguage(this.settings.language);
   }
 
   async activateViewInMainArea() {

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -1,6 +1,8 @@
 import { App, PluginSettingTab, Setting } from "obsidian";
 import TasksMapPlugin from "../main";
 import { getTagColor } from "../lib/utils";
+import { t } from "../i18n";
+import { SUPPORTED_LANGUAGES } from "../i18n";
 
 export class TasksMapSettingTab extends PluginSettingTab {
   plugin: TasksMapPlugin;
@@ -50,11 +52,30 @@ export class TasksMapSettingTab extends PluginSettingTab {
 
     containerEl.empty();
 
-    new Setting(containerEl).setHeading().setName("Display Options");
+    new Setting(containerEl)
+      .setName(t("settings.language"))
+      .setDesc(t("settings.language_desc"))
+      .addDropdown((dropdown) => {
+        SUPPORTED_LANGUAGES.forEach((lang) => {
+          dropdown.addOption(lang.value, lang.label);
+        });
+        dropdown
+          .setValue(this.plugin.settings.language)
+          .onChange(async (value) => {
+            this.plugin.settings.language = value as "en" | "nl" | "zh-CN";
+            await this.plugin.saveSettings();
+            // Redraw the settings tab with new language
+            this.display();
+          });
+      });
 
     new Setting(containerEl)
-      .setName("Show task priorities")
-      .setDesc("Display priority indicators on task nodes")
+      .setHeading()
+      .setName(t("settings.display_options"));
+
+    new Setting(containerEl)
+      .setName(t("settings.show_task_priorities"))
+      .setDesc(t("settings.show_task_priorities_desc"))
       .addToggle((toggle) =>
         toggle
           .setValue(this.plugin.settings.showPriorities)
@@ -65,8 +86,8 @@ export class TasksMapSettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
-      .setName("Show task tags")
-      .setDesc("Display tags on task nodes")
+      .setName(t("settings.show_task_tags"))
+      .setDesc(t("settings.show_task_tags_desc"))
       .addToggle((toggle) =>
         toggle
           .setValue(this.plugin.settings.showTags)
@@ -76,15 +97,15 @@ export class TasksMapSettingTab extends PluginSettingTab {
           })
       );
 
-    new Setting(containerEl).setHeading().setName("Layout");
+    new Setting(containerEl).setHeading().setName(t("settings.layout"));
 
     new Setting(containerEl)
-      .setName("Layout direction")
-      .setDesc("Direction for the node layout")
+      .setName(t("settings.layout_direction"))
+      .setDesc(t("settings.layout_direction_desc"))
       .addDropdown((dropdown) =>
         dropdown
-          .addOption("Horizontal", "Horizontal")
-          .addOption("Vertical", "Vertical")
+          .addOption("Horizontal", t("settings.layout_horizontal"))
+          .addOption("Vertical", t("settings.layout_vertical"))
           .setValue(this.plugin.settings.layoutDirection)
           .onChange(async (value) => {
             this.plugin.settings.layoutDirection = value as
@@ -94,15 +115,15 @@ export class TasksMapSettingTab extends PluginSettingTab {
           })
       );
 
-    new Setting(containerEl).setHeading().setName("Tag Appearance");
+    new Setting(containerEl).setHeading().setName(t("settings.tag_appearance"));
 
     new Setting(containerEl)
-      .setName("Tag color mode")
-      .setDesc("Choose how tag colors are generated")
+      .setName(t("settings.tag_color_mode"))
+      .setDesc(t("settings.tag_color_mode_desc"))
       .addDropdown((dropdown) =>
         dropdown
-          .addOption("random", "Random colors (seeded)")
-          .addOption("static", "Static color for all tags")
+          .addOption("random", t("settings.tag_color_random"))
+          .addOption("static", t("settings.tag_color_static"))
           .setValue(this.plugin.settings.tagColorMode)
           .onChange(async (value) => {
             this.plugin.settings.tagColorMode = value as "random" | "static";
@@ -113,10 +134,8 @@ export class TasksMapSettingTab extends PluginSettingTab {
 
     if (this.plugin.settings.tagColorMode === "random") {
       new Setting(containerEl)
-        .setName("Color seed")
-        .setDesc(
-          "Seed value for random color generation (same seed = same colors)"
-        )
+        .setName(t("settings.color_seed"))
+        .setDesc(t("settings.color_seed_desc"))
         .addText((text) =>
           text
             .setPlaceholder("42")
@@ -142,8 +161,8 @@ export class TasksMapSettingTab extends PluginSettingTab {
 
       // Add preview container for random mode
       const previewSetting = new Setting(containerEl)
-        .setName("Preview")
-        .setDesc("Example tags with random colors");
+        .setName(t("settings.preview"))
+        .setDesc(t("settings.preview_random_desc"));
 
       this.createTagPreview(
         previewSetting.settingEl,
@@ -155,8 +174,8 @@ export class TasksMapSettingTab extends PluginSettingTab {
 
     if (this.plugin.settings.tagColorMode === "static") {
       new Setting(containerEl)
-        .setName("Static tag color")
-        .setDesc("Color to use for all tags")
+        .setName(t("settings.static_tag_color"))
+        .setDesc(t("settings.static_tag_color_desc"))
         .addColorPicker((colorPicker) =>
           colorPicker
             .setValue(this.plugin.settings.tagStaticColor)
@@ -181,8 +200,8 @@ export class TasksMapSettingTab extends PluginSettingTab {
 
       // Add preview container for static mode
       const previewSetting = new Setting(containerEl)
-        .setName("Preview")
-        .setDesc("Example tags with static color");
+        .setName(t("settings.preview"))
+        .setDesc(t("settings.preview_static_desc"));
 
       this.createTagPreview(
         previewSetting.settingEl,
@@ -193,16 +212,18 @@ export class TasksMapSettingTab extends PluginSettingTab {
       );
     }
 
-    new Setting(containerEl).setHeading().setName("Simple Task Relations");
+    new Setting(containerEl)
+      .setHeading()
+      .setName(t("settings.simple_task_relations"));
 
     new Setting(containerEl)
-      .setName("Linking style")
-      .setDesc("How task dependencies are specified in simple tasks")
+      .setName(t("settings.linking_style"))
+      .setDesc(t("settings.linking_style_desc"))
       .addDropdown((dropdown) =>
         dropdown
-          .addOption("csv", "CSV (Tasks plugin default)")
-          .addOption("individual", "Individual")
-          .addOption("dataview", "Dataview")
+          .addOption("csv", t("settings.linking_csv"))
+          .addOption("individual", t("settings.linking_individual"))
+          .addOption("dataview", t("settings.linking_dataview"))
           .setValue(this.plugin.settings.linkingStyle)
           .onChange(async (value) => {
             this.plugin.settings.linkingStyle = value as
@@ -225,59 +246,60 @@ export class TasksMapSettingTab extends PluginSettingTab {
         const title = previewContainer.createDiv({
           cls: "tasks-map-preview-title",
         });
-        title.textContent = "Individual Style:";
+        title.textContent = t("settings.linking_individual_title");
 
         const desc = previewContainer.createDiv({
           cls: "tasks-map-preview-desc",
         });
-        desc.textContent = "Each dependency with its own emoji identifier";
+        desc.textContent = t("settings.linking_individual_desc");
 
         const example = previewContainer.createDiv({
           cls: "tasks-map-preview-example",
         });
-        example.textContent = "- [ ] My task ⛔ abc123 ⛔ def456 ⛔ ghi789";
+        example.textContent = t("settings.linking_individual_example");
       } else if (style === "dataview") {
         const title = previewContainer.createDiv({
           cls: "tasks-map-preview-title",
         });
-        title.textContent = "Dataview Style:";
+        title.textContent = t("settings.linking_dataview_title");
 
         const desc = previewContainer.createDiv({
           cls: "tasks-map-preview-desc",
         });
-        desc.textContent = "Dependencies using Dataview inline field syntax";
+        desc.textContent = t("settings.linking_dataview_desc");
 
         const example = previewContainer.createDiv({
           cls: "tasks-map-preview-example",
         });
-        example.textContent =
-          "- [ ] My task [[dependsOn:: abc123,def456,ghi789]]";
+        example.textContent = t("settings.linking_dataview_example");
       } else {
         const title = previewContainer.createDiv({
           cls: "tasks-map-preview-title",
         });
-        title.textContent = "CSV Style (Tasks plugin default):";
+        title.textContent = t("settings.linking_csv_title");
 
         const desc = previewContainer.createDiv({
           cls: "tasks-map-preview-desc",
         });
-        desc.textContent = "Multiple dependencies comma-separated";
+        desc.textContent = t("settings.linking_csv_desc");
 
         const example = previewContainer.createDiv({
           cls: "tasks-map-preview-example",
         });
-        example.textContent = "- [ ] My task ⛔ abc123,def456,ghi789";
+        example.textContent = t("settings.linking_csv_example");
       }
     };
 
     // Initialize preview
     updatePreview(this.plugin.settings.linkingStyle);
 
-    new Setting(containerEl).setHeading().setName("Advanced Options");
+    new Setting(containerEl)
+      .setHeading()
+      .setName(t("settings.advanced_options"));
 
     new Setting(containerEl)
-      .setName("Debug visualization")
-      .setDesc("Show additional debug information in the graph view")
+      .setName(t("settings.debug_visualization"))
+      .setDesc(t("settings.debug_visualization_desc"))
       .addToggle((toggle) =>
         toggle
           .setValue(this.plugin.settings.debugVisualization)

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,3 +1,5 @@
+import { Language } from "../i18n";
+
 export interface TasksMapSettings {
   showPriorities: boolean;
   showTags: boolean;
@@ -11,6 +13,9 @@ export interface TasksMapSettings {
   tagColorMode: "random" | "static";
   tagColorSeed: number;
   tagStaticColor: string;
+
+  // Language setting
+  language: Language;
 }
 
 export const DEFAULT_SETTINGS: TasksMapSettings = {
@@ -26,4 +31,7 @@ export const DEFAULT_SETTINGS: TasksMapSettings = {
   tagColorMode: "random",
   tagColorSeed: 42,
   tagStaticColor: "#3b82f6",
+
+  // Language default
+  language: "en",
 };

--- a/src/views/TaskMapGraphItemView.tsx
+++ b/src/views/TaskMapGraphItemView.tsx
@@ -8,6 +8,7 @@ import { checkDataviewPlugin } from "../lib/utils";
 import TasksMapPlugin from "../main";
 import { TaskStatus } from "src/types/task";
 import { TasksMapSettings } from "src/types/settings";
+import { t } from "../i18n";
 
 const ALL_STATUSES: TaskStatus[] = ["todo", "in_progress", "done", "canceled"];
 
@@ -58,7 +59,7 @@ export default class TaskMapGraphItemView extends ItemView {
   }
 
   getDisplayText() {
-    return "Tasks map";
+    return t("view.title");
   }
 
   async onOpen() {
@@ -86,15 +87,13 @@ export default class TaskMapGraphItemView extends ItemView {
           <div className="tasks-map-centered-message-content">
             <div className="tasks-map-message-icon">⚠️</div>
             <h3 className="tasks-map-message-title">
-              Tasks Map requires the Dataview plugin to be installed and
-              enabled.
+              {t("view.dataview_required")}
             </h3>
             <p className="tasks-map-message-description">
               {dataviewCheck.getMessage()}
             </p>
             <p className="tasks-map-message-description">
-              Visit the Community Plugins section in Settings to install or
-              enable Dataview.
+              {t("view.visit_community_plugins")}
             </p>
           </div>
         </div>

--- a/src/views/TaskMapGraphView.tsx
+++ b/src/views/TaskMapGraphView.tsx
@@ -24,6 +24,7 @@ import { TaskMinimap } from "src/components/task-minimap";
 import HashEdge from "src/components/hash-edge";
 import { DeleteEdgeButton } from "src/components/delete-edge-button";
 import { TagsContext } from "src/contexts/context";
+import { t } from "../i18n";
 
 import { TaskStatus } from "src/types/task";
 import { TasksMapSettings } from "src/types/settings";
@@ -347,10 +348,7 @@ export default function TaskMapGraphView({
       if (!vault || !sourceTask || !targetTask) return;
 
       if (sourceTask.type !== targetTask.type) {
-        new Notice(
-          "Cannot create edges between different task types (dataview and note-based tasks). Both tasks must be of the same type.",
-          5000
-        );
+        new Notice(t("errors.cannot_create_edges_different_types"), 5000);
         return;
       }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "importHelpers": true,
     "isolatedModules": true,
     "strictNullChecks": true,
+    "resolveJsonModule": true,
     "lib": [
       "DOM",
       "ES5",


### PR DESCRIPTION
This release brings support for `en`, `nl`, and `zh-CN` internationalisation (i18n).

Whilst initial translations might be sub-optimal, this is a good start.

Closes #178 