### PR TITLE
fix: single bracket for dataview id and link properties

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -50,7 +50,7 @@
     "linking_individual_example": "- [ ] My task ⛔ abc123 ⛔ def456 ⛔ ghi789",
     "linking_dataview_title": "Dataview Style:",
     "linking_dataview_desc": "Dependencies using Dataview inline field syntax",
-    "linking_dataview_example": "- [ ] My task [[dependsOn:: abc123,def456,ghi789]]",
+    "linking_dataview_example": "- [ ] My task [dependsOn:: abc123,def456,ghi789]",
     "linking_csv_title": "CSV Style (Tasks plugin default):",
     "linking_csv_desc": "Multiple dependencies comma-separated",
     "linking_csv_example": "- [ ] My task ⛔ abc123,def456,ghi789",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -50,7 +50,7 @@
     "linking_individual_example": "- [ ] Mijn taak ⛔ abc123 ⛔ def456 ⛔ ghi789",
     "linking_dataview_title": "Dataview Stijl:",
     "linking_dataview_desc": "Afhankelijkheden met Dataview inline veldsyntax",
-    "linking_dataview_example": "- [ ] Mijn taak [[dependsOn:: abc123,def456,ghi789]]",
+    "linking_dataview_example": "- [ ] Mijn taak [dependsOn:: abc123,def456,ghi789]",
     "linking_csv_title": "CSV Stijl (Taken plugin standaard):",
     "linking_csv_desc": "Meerdere afhankelijkheden gescheiden door komma's",
     "linking_csv_example": "- [ ] Mijn taak ⛔ abc123,def456,ghi789",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -50,7 +50,7 @@
     "linking_individual_example": "- [ ] 我的任务 ⛔ abc123 ⛔ def456 ⛔ ghi789",
     "linking_dataview_title": "Dataview 样式：",
     "linking_dataview_desc": "使用 Dataview 内联字段语法的依赖项",
-    "linking_dataview_example": "- [ ] 我的任务 [[dependsOn:: abc123,def456,ghi789]]",
+    "linking_dataview_example": "- [ ] 我的任务 [dependsOn:: abc123,def456,ghi789]",
     "linking_csv_title": "CSV 样式（任务插件默认）：",
     "linking_csv_desc": "多个依赖项用逗号分隔",
     "linking_csv_example": "- [ ] 我的任务 ⛔ abc123,def456,ghi789",

--- a/src/lib/task-factory.ts
+++ b/src/lib/task-factory.ts
@@ -63,7 +63,7 @@ export class TaskFactory {
       return idMatch[1];
     }
 
-    // Try Dataview format: [[id:: abc123]]
+    // Try Dataview format: [id:: abc123]
     const dataviewMatch = text.match(DATAVIEW_ID_PATTERN);
 
     if (dataviewMatch) {
@@ -149,7 +149,7 @@ export class TaskFactory {
   }
 
   private parseDataviewStyleLinks(text: string): string[] {
-    // Parse Dataview format: [[dependsOn:: abc123,def456]]
+    // Parse Dataview format: [dependsOn:: abc123,def456]
     const dataviewMatches = Array.from(text.matchAll(DATAVIEW_DEPENDS_PATTERN));
     const ids: string[] = [];
 
@@ -165,10 +165,10 @@ export class TaskFactory {
     return text
       .replace(/(?:^|\s)#\S+/g, "")
       .replace(EMOJI_ID_PATTERN_GLOBAL, "") // Remove task IDs: 🆔 abc123
-      .replace(DATAVIEW_ID_PATTERN_GLOBAL, "") // Remove Dataview IDs: [[id:: abc123]]
+      .replace(DATAVIEW_ID_PATTERN_GLOBAL, "") // Remove Dataview IDs: [id:: abc123]
       .replace(CSV_LINKS_PATTERN, "") // Remove CSV links: ⛔ abc123,def456
       .replace(INDIVIDUAL_LINKS_PATTERN, "") // Remove individual links: ⛔ abc123
-      .replace(DATAVIEW_DEPENDS_PATTERN, "") // Remove Dataview dependencies: [[dependsOn:: abc123,def456]]
+      .replace(DATAVIEW_DEPENDS_PATTERN, "") // Remove Dataview dependencies: [dependsOn:: abc123,def456]
       .replace(STAR_PATTERN_GLOBAL, "") // Remove star emoji: ⭐
       .replace(/([\p{Extended_Pictographic}]+(\s*[#a-zA-Z0-9_-]+)?)/gu, "") // Remove other emojis
       .replace(/([\p{Extended_Pictographic}]+)/gu, "") // Remove remaining emojis

--- a/src/lib/task-regex.ts
+++ b/src/lib/task-regex.ts
@@ -4,22 +4,22 @@
 
 // ID patterns - for matching and capturing IDs (no 'g' flag for .match())
 export const EMOJI_ID_PATTERN = /🆔\s*([a-zA-Z0-9]{6})/i;
-export const DATAVIEW_ID_PATTERN = /\[\[id::\s*([a-zA-Z0-9]{6})\]\]/i;
+export const DATAVIEW_ID_PATTERN = /\[id::\s*([a-zA-Z0-9]{6})\]/i;
 
 // ID patterns for removal/global replacement (with 'g' flag)
 export const EMOJI_ID_PATTERN_GLOBAL = /🆔\s*[a-zA-Z0-9]{6}/gi;
-export const DATAVIEW_ID_PATTERN_GLOBAL = /\[\[id::\s*[a-zA-Z0-9]{6}\]\]/gi;
+export const DATAVIEW_ID_PATTERN_GLOBAL = /\[id::\s*[a-zA-Z0-9]{6}\]/gi;
 
 // Dependency/link patterns - for matching and capturing dependencies
 export const CSV_LINKS_PATTERN = /⛔\s*([a-zA-Z0-9]{6}(?:,[a-zA-Z0-9]{6})*)/g;
 export const INDIVIDUAL_LINKS_PATTERN =
   /⛔\s*([a-zA-Z0-9]{6})(?!,[a-zA-Z0-9]{6})/g;
 export const DATAVIEW_DEPENDS_PATTERN =
-  /\[\[dependsOn::\s*([a-zA-Z0-9]{6}(?:,\s*[a-zA-Z0-9]{6})*)\]\]/g;
+  /\[dependsOn::\s*([a-zA-Z0-9]{6}(?:,\s*[a-zA-Z0-9]{6})*)\]/g;
 
 // Cleaning patterns - for removing metadata (no capture groups)
 export const EMOJI_ID_REMOVAL = /🆔\s+\S+/g;
-export const DATAVIEW_ID_REMOVAL = /\[\[id::\s*\S+\]\]/g;
+export const DATAVIEW_ID_REMOVAL = /\[id::\s*\S+\]/g;
 export const TAG_REMOVAL = /#\S+/g;
 export const WHITESPACE_NORMALIZE = /\s+/g;
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -121,7 +121,7 @@ export function estimateNodeDimensions(
 
 /**
  * Find the index of a task line in an array of lines by its ID.
- * Supports both emoji format (🆔 abc123) and Dataview format ([[id:: abc123]])
+ * Supports both emoji format (🆔 abc123) and Dataview format ([id:: abc123])
  */
 export function findTaskLineByIdOrText(
   lines: string[],
@@ -137,7 +137,7 @@ export function findTaskLineByIdOrText(
 
   // Try to find by Dataview format ID
   taskLineIdx = lines.findIndex((line: string) =>
-    line.includes(`[[id:: ${taskId}]]`)
+    line.includes(`[id:: ${taskId}]`)
   );
 
   if (taskLineIdx !== -1) return taskLineIdx;
@@ -440,7 +440,7 @@ export async function addSignToTaskInFile(
     if (type === "id") {
       // Check if any ID format is already present
       const emojiIdPresent = /🆔\s*[a-zA-Z0-9]{6}/.test(lines[taskLineIdx]);
-      const dataviewIdPresent = /\[\[id::\s*[a-zA-Z0-9]{6}\]\]/.test(
+      const dataviewIdPresent = /\[id::\s*[a-zA-Z0-9]{6}\]/.test(
         lines[taskLineIdx]
       );
 
@@ -448,7 +448,7 @@ export async function addSignToTaskInFile(
 
       // Add ID in the configured format
       if (linkingStyle === "dataview") {
-        const sign = `[[id:: ${hash}]]`;
+        const sign = `[id:: ${hash}]`;
         if (lines[taskLineIdx].includes(sign)) return fileContent;
         lines[taskLineIdx] = lines[taskLineIdx] + " " + sign;
       } else {
@@ -461,15 +461,15 @@ export async function addSignToTaskInFile(
       // Detect if task is using Dataview format (or if it's the configured style)
       const usesDataviewFormat =
         linkingStyle === "dataview" ||
-        /\[\[id::\s*[a-zA-Z0-9]{6}\]\]/.test(lines[taskLineIdx]) ||
-        /\[\[dependsOn::\s*[a-zA-Z0-9]{6}(?:,\s*[a-zA-Z0-9]{6})*\]\]/.test(
+        /\[id::\s*[a-zA-Z0-9]{6}\]/.test(lines[taskLineIdx]) ||
+        /\[dependsOn::\s*[a-zA-Z0-9]{6}(?:,\s*[a-zA-Z0-9]{6})*\]/.test(
           lines[taskLineIdx]
         );
 
       if (usesDataviewFormat) {
         // Handle Dataview format dependencies
         const dataviewRegex =
-          /\[\[dependsOn::\s*([a-zA-Z0-9]{6}(?:,\s*[a-zA-Z0-9]{6})*)\]\]/;
+          /\[dependsOn::\s*([a-zA-Z0-9]{6}(?:,\s*[a-zA-Z0-9]{6})*)\]/;
         const dataviewMatch = lines[taskLineIdx].match(dataviewRegex);
 
         if (dataviewMatch) {
@@ -481,12 +481,12 @@ export async function addSignToTaskInFile(
             const newList = [...existingIds, hash].join(", ");
             lines[taskLineIdx] = lines[taskLineIdx].replace(
               dataviewRegex,
-              `[[dependsOn:: ${newList}]]`
+              `[dependsOn:: ${newList}]`
             );
           }
         } else {
           // No existing Dataview dependencies, add new one
-          lines[taskLineIdx] = lines[taskLineIdx] + ` [[dependsOn:: ${hash}]]`;
+          lines[taskLineIdx] = lines[taskLineIdx] + ` [dependsOn:: ${hash}]`;
         }
       } else {
         // Handle emoji format stop signs based on linking style
@@ -584,7 +584,7 @@ export async function removeSignFromTaskInFile(
       }
 
       // Remove Dataview ID sign
-      const dataviewSign = `[[id:: ${hash}]]`;
+      const dataviewSign = `[id:: ${hash}]`;
       if (lines[taskLineIdx].includes(dataviewSign)) {
         lines[taskLineIdx] = lines[taskLineIdx]
           .replace(dataviewSign, "")
@@ -593,7 +593,7 @@ export async function removeSignFromTaskInFile(
     } else if (type === "stop") {
       // First try Dataview format
       const dataviewRegex =
-        /\[\[dependsOn::\s*([a-zA-Z0-9]{6}(?:,\s*[a-zA-Z0-9]{6})*)\]\]/;
+        /\[dependsOn::\s*([a-zA-Z0-9]{6}(?:,\s*[a-zA-Z0-9]{6})*)\]/;
       const dataviewMatch = lines[taskLineIdx].match(dataviewRegex);
 
       if (dataviewMatch) {
@@ -610,7 +610,7 @@ export async function removeSignFromTaskInFile(
           const newList = filteredIds.join(", ");
           lines[taskLineIdx] = lines[taskLineIdx].replace(
             dataviewRegex,
-            `[[dependsOn:: ${newList}]]`
+            `[dependsOn:: ${newList}]`
           );
         }
       } else {

--- a/test/fixture/Dataview format tasks.md
+++ b/test/fixture/Dataview format tasks.md
@@ -1,4 +1,4 @@
-- [ ] Do this first [[id:: dcf64c]]
-- [ ] Do this after first and some other task [[dependsOn:: dcf64c, 0h17ye]]
-- [ ] Another independent task [[id:: 0h17ye]]
-- [ ] Final task depending on all [[dependsOn:: dcf64c, 0h17ye]] ⭐
+- [ ] Do this first [id:: dcf64c]
+- [ ] Do this after first and some other task [dependsOn:: dcf64c, 0h17ye]
+- [ ] Another independent task [id:: 0h17ye]
+- [ ] Final task depending on all [dependsOn:: dcf64c, 0h17ye] ⭐

--- a/test/fixture/Mixed format tasks.md
+++ b/test/fixture/Mixed format tasks.md
@@ -9,14 +9,14 @@ This file demonstrates that the plugin supports both emoji and Dataview formats 
 
 ## Dataview Format (New)
 
-- [ ] Design architecture #dataview  [[id:: 7f3yaw]]
-- [ ] Implement feature #dataview  [[dependsOn:: 7f3yaw]] [[id:: jmhi6u]]
-- [ ] Write tests #dataview  [[dependsOn:: jmhi6u]] [[id:: i2a0b2]]
-- [ ] ⭐ Deploy to production #dataview  [[dependsOn:: jmhi6u, i2a0b2]]
+- [ ] Design architecture #dataview [id:: 7f3yaw]
+- [ ] Implement feature #dataview [dependsOn:: 7f3yaw] [id:: jmhi6u]
+- [ ] Write tests #dataview [dependsOn:: jmhi6u] [id:: i2a0b2]
+- [ ] ⭐ Deploy to production #dataview [dependsOn:: jmhi6u, i2a0b2]
 
 ## Mixed Format (Both Styles)
 
 You can even mix both styles in the same vault (though not recommended in the same task):
 
 - [ ] Task with emoji ID #mixed 🆔 mno345
-- [ ] Task with dataview dependency #mixed [[dependsOn:: mno345]]
+- [ ] Task with dataview dependency #mixed [dependsOn:: mno345]


### PR DESCRIPTION

This pull request updates the syntax for Dataview-style task IDs and dependencies throughout the codebase, changing from double brackets (e.g., `[[id:: abc123]]`) to single brackets (e.g., `[id:: abc123]`). This affects regex patterns, code logic, documentation, and test fixtures to ensure consistency and correct parsing of the new format.

**Dataview Syntax Update:**

* All regex patterns in `src/lib/task-regex.ts` and their usages in `src/lib/task-factory.ts` and `src/lib/utils.ts` have been updated to match and process Dataview IDs and dependencies using single brackets instead of double brackets. [[1]](diffhunk://#diff-46e326c7b3f56f530abee7955919b2cd237614cfb7985168fe4da755112cf2beL7-R22) [[2]](diffhunk://#diff-be37b8538e60a5182c29ee606bdecc755a16e13b79d2df60ee53cb880931b492L66-R66) [[3]](diffhunk://#diff-be37b8538e60a5182c29ee606bdecc755a16e13b79d2df60ee53cb880931b492L152-R152) [[4]](diffhunk://#diff-be37b8538e60a5182c29ee606bdecc755a16e13b79d2df60ee53cb880931b492L168-R171) [[5]](diffhunk://#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224L124-R124) [[6]](diffhunk://#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224L140-R140) [[7]](diffhunk://#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224L443-R451) [[8]](diffhunk://#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224L464-R472) [[9]](diffhunk://#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224L484-R489) [[10]](diffhunk://#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224L587-R587) [[11]](diffhunk://#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224L596-R596) [[12]](diffhunk://#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224L613-R613)

**Localization and Documentation:**

* Example tasks in English, Dutch, and Chinese locale files now show the new single-bracket Dataview format. [[1]](diffhunk://#diff-86d6ad78f4bfa98b2f9fc37e63d2f4c94b23dc54736ab069327947546c55ccd0L53-R53) [[2]](diffhunk://#diff-a0823e318a3294180c37658bb6c26c4090bbf521493cfaf8622db1eae716059cL53-R53) [[3]](diffhunk://#diff-295b6bdd6d001e776abf7c173ada4a1de77f4c7c0d7804f8080c7a229e404f04L53-R53)

**Test Fixtures:**

* All test fixtures and documentation in `test/fixture/Dataview format tasks.md` and `test/fixture/Mixed format tasks.md` have been updated to use the new single-bracket Dataview syntax. [[1]](diffhunk://#diff-c00dced1e3fc849bbd4c91f598f1a23583c832fb160774ba4a6aa28fb7e7c756L1-R4) [[2]](diffhunk://#diff-9e92cebf5fad3ce9502a2f6e785876c30e7b8f1ccf9ed91fa75c953e400ee3fcL12-R22)