### PR TITLE
chore: don't auto merge majors

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,11 @@
 			"matchPackageNames": ["@dagrejs/dagre"],
 			"allowedVersions": "<2.0.0",
 			"description": "Pin dagre to v1.x - v2 has bundling issues with external graphlib dependency"
-		}
+		},
+        {
+            "matchUpdateTypes": ["major"],
+            "automerge": false,
+            "description": "Do not automerge major updates"
+        }
 	]
 }


### PR DESCRIPTION
This pull request updates the `renovate.json` configuration to improve the control over dependency updates. The most important change is the addition of a rule to prevent automatic merging of major updates.

Dependency update policy:

* Added a new rule to the `renovate.json` file to prevent automerging of major updates by setting `"automerge": false` for updates with `"matchUpdateTypes": ["major"]`. This ensures that major dependency updates will require manual review before being merged.