### PR TITLE
chore: simplify rules to account for `semVersie` auto-labeling

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,18 +8,6 @@
 	"automergeType": "pr",
 	"packageRules": [
 		{
-			"matchDepTypes": ["devDependencies"],
-			"labels": ["semver-noimpact"]
-		},
-		{
-			"matchManagers": ["github-actions"],
-			"labels": ["semver-noimpact"]
-		},
-		{
-			"matchDepTypes": ["dependencies"],
-			"labels": ["semver-patch"]
-		},
-		{
 			"matchPackageNames": ["@dagrejs/dagre"],
 			"allowedVersions": "<2.0.0",
 			"description": "Pin dagre to v1.x - v2 has bundling issues with external graphlib dependency"


### PR DESCRIPTION
Removed unnecessary package rules for dependencies.