### PR TITLE
feat: drag and drop projects into project

### DIFF
--- a/global.css
+++ b/global.css
@@ -1900,6 +1900,12 @@ If your plugin does not need CSS, delete this file.
   box-shadow: 0 0 0 2px var(--background-modifier-border-focus);
 }
 
+.tasks-map-project-group.drag-over {
+  border-color: var(--interactive-accent);
+  box-shadow: 0 0 0 2px var(--interactive-accent);
+  background-color: var(--background-modifier-hover);
+}
+
 .tasks-map-project-group-label {
   display: flex;
   align-items: center;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2861,9 +2861,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2878,9 +2875,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2895,9 +2889,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2912,9 +2903,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2929,9 +2917,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2946,9 +2931,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2963,9 +2945,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2980,9 +2959,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [

--- a/src/components/project-group-node.tsx
+++ b/src/components/project-group-node.tsx
@@ -4,14 +4,22 @@ import { FolderOpen } from "lucide-react";
 
 export interface ProjectGroupNodeData {
   label: string;
+  isDragOver?: boolean;
 }
 
 export default function ProjectGroupNode({
   data,
   selected,
 }: NodeProps<ProjectGroupNodeData>) {
+  const classes = [
+    "tasks-map-project-group",
+    selected ? "selected" : "",
+    data.isDragOver ? "drag-over" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
   return (
-    <div className={`tasks-map-project-group${selected ? " selected" : ""}`}>
+    <div className={classes}>
       <NodeResizer minWidth={100} minHeight={100} isVisible={selected} />
       <div className="tasks-map-project-group-label">
         <FolderOpen size={13} />

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -125,6 +125,9 @@
   "errors": {
     "cannot_create_edges_different_types": "Cannot create edges between different task types (dataview and note-based tasks). Both tasks must be of the same type."
   },
+  "notices": {
+    "project_assigned": "Added to project: {{projectName}}"
+  },
   "presets": {
     "panel_title": "Saved Filters",
     "expand_panel": "Expand presets panel",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -125,6 +125,9 @@
   "errors": {
     "cannot_create_edges_different_types": "Kan geen verbindingen maken tussen verschillende taaktypes (dataview en notitie-gebaseerde taken). Beide taken moeten van hetzelfde type zijn."
   },
+  "notices": {
+    "project_assigned": "Toegevoegd aan project: {{projectName}}"
+  },
   "presets": {
     "panel_title": "Opgeslagen filters",
     "expand_panel": "Voorinstellingen paneel uitklappen",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -125,6 +125,9 @@
   "errors": {
     "cannot_create_edges_different_types": "无法在不同任务类型（dataview 和基于笔记的任务）之间创建连接。两个任务必须是相同类型。"
   },
+  "notices": {
+    "project_assigned": "已添加到项目：{{projectName}}"
+  },
   "presets": {
     "panel_title": "已保存的筛选器",
     "expand_panel": "展开预设面板",

--- a/src/types/note-task.ts
+++ b/src/types/note-task.ts
@@ -251,6 +251,64 @@ export class NoteTask extends BaseTask {
     });
   }
 
+  async addProject(app: App, projectName: string): Promise<void> {
+    if (!this.link || !this.text) return;
+    const vault = app?.vault;
+    if (!vault) return;
+    const file = vault.getFileByPath(this.link);
+    if (!file) return;
+
+    await vault.process(file, (fileContent) => {
+      const lines = fileContent.split(/\r?\n/);
+      const { frontmatterStart, frontmatterEnd } = this.findFrontmatter(lines);
+
+      if (frontmatterStart === -1 || frontmatterEnd === -1) {
+        return fileContent;
+      }
+
+      // Find projects section
+      let i = frontmatterStart + 1;
+      let projectsLineIdx = -1;
+      while (i < frontmatterEnd) {
+        if (lines[i] === "projects:") {
+          projectsLineIdx = i;
+          break;
+        }
+        i++;
+      }
+
+      // If projects section doesn't exist, add it
+      if (projectsLineIdx === -1) {
+        lines.splice(
+          frontmatterEnd,
+          0,
+          "projects:",
+          `  - "[[${projectName}]]"`
+        );
+        return lines.join("\n");
+      }
+
+      // Check if project already exists
+      i = projectsLineIdx + 1;
+      while (i < frontmatterEnd && lines[i].match(/^\s{2}- /)) {
+        const entryMatch = lines[i].match(/^\s{2}- (.+)$/);
+        if (entryMatch) {
+          const raw = entryMatch[1].replace(/^"|"$/g, "");
+          const wikiMatch = raw.match(/^\[\[(.+)\]\]$/);
+          const existing = wikiMatch ? wikiMatch[1] : raw;
+          if (existing === projectName) {
+            return fileContent;
+          }
+        }
+        i++;
+      }
+
+      // Append project entry
+      lines.splice(i, 0, `  - "[[${projectName}]]"`);
+      return lines.join("\n");
+    });
+  }
+
   async addLinkMetadata(vault: Vault, fromTask: BaseTask): Promise<void> {
     await this.addDependencyToFrontmatter(vault, fromTask);
   }

--- a/src/views/TaskMapGraphView.tsx
+++ b/src/views/TaskMapGraphView.tsx
@@ -5,6 +5,7 @@ import ReactFlow, {
   useEdgesState,
   addEdge,
   useReactFlow,
+  type NodeDragHandler,
 } from "reactflow";
 import { Notice } from "obsidian";
 import { useApp } from "src/hooks/hooks";
@@ -23,6 +24,7 @@ import {
   parseTaskLine,
 } from "src/lib/utils";
 import { BaseTask } from "src/types/task";
+import { NoteTask } from "src/types/note-task";
 import GuiOverlay from "src/components/gui-overlay";
 import FilterPresetsPanel from "src/components/filter-presets-panel";
 import StatusCountsOverlay from "src/components/status-counts-overlay";
@@ -572,9 +574,79 @@ export default function TaskMapGraphView({
     [createConnectedTask, tasks]
   );
 
+  // Returns the project group node id that contains the given position, or null
+  const findGroupAtPosition = useCallback(
+    (pos: { x: number; y: number }): string | null => {
+      for (const groupNode of nodes.filter((n) => n.type === "projectGroup")) {
+        const { x, y } = groupNode.position;
+        const w =
+          groupNode.width ??
+          (groupNode.style?.width as number | undefined) ??
+          0;
+        const h =
+          groupNode.height ??
+          (groupNode.style?.height as number | undefined) ??
+          0;
+        if (pos.x >= x && pos.x <= x + w && pos.y >= y && pos.y <= y + h) {
+          return groupNode.id;
+        }
+      }
+      return null;
+    },
+    [nodes]
+  );
+
+  // Highlight project group node while a task node is dragged over it
+  const onNodeDrag: NodeDragHandler = useCallback(
+    (_event, draggedNode) => {
+      if (draggedNode.type !== "task") return;
+      const dragPos = draggedNode.positionAbsolute ?? draggedNode.position;
+      const hoveredGroupId = findGroupAtPosition(dragPos);
+      setNodes((nds) =>
+        nds.map((n) => {
+          if (n.type !== "projectGroup") return n;
+          const isDragOver = n.id === hoveredGroupId;
+          if ((n.data as { isDragOver?: boolean }).isDragOver === isDragOver)
+            return n;
+          return { ...n, data: { ...n.data, isDragOver } };
+        })
+      );
+    },
+    [findGroupAtPosition, setNodes]
+  );
+
+  // Handle drag-stop of a graph task node — assign to project if dropped inside a group
+  const onNodeDragStop: NodeDragHandler = useCallback(
+    async (_event, draggedNode) => {
+      // Clear all drag-over highlights
+      setNodes((nds) =>
+        nds.map((n) => {
+          if (n.type !== "projectGroup") return n;
+          if (!(n.data as { isDragOver?: boolean }).isDragOver) return n;
+          return { ...n, data: { ...n.data, isDragOver: false } };
+        })
+      );
+
+      if (draggedNode.type !== "task") return;
+      const task = tasks.find((t) => t.id === draggedNode.id);
+      if (!(task instanceof NoteTask)) return;
+
+      const dragPos = draggedNode.positionAbsolute ?? draggedNode.position;
+      const groupId = findGroupAtPosition(dragPos);
+      if (!groupId) return;
+
+      const groupNode = nodes.find((n) => n.id === groupId);
+      if (!groupNode) return;
+      const projectName = (groupNode.data as { label: string }).label;
+      await task.addProject(app, projectName);
+      new Notice(t("notices.project_assigned", { projectName }));
+    },
+    [tasks, nodes, app, findGroupAtPosition, setNodes]
+  );
+
   // Handle drop of an unlinked task from the sidebar onto the graph canvas
   const onDrop = useCallback(
-    (event: React.DragEvent<HTMLDivElement>) => {
+    async (event: React.DragEvent<HTMLDivElement>) => {
       event.preventDefault();
       const taskId = event.dataTransfer.getData(DRAG_DATA_KEY);
       if (!taskId) return;
@@ -587,6 +659,35 @@ export default function TaskMapGraphView({
         x: event.clientX,
         y: event.clientY,
       });
+
+      // Check if drop landed inside a project group node
+      if (task instanceof NoteTask) {
+        const projectGroupNodes = nodes.filter(
+          (n) => n.type === "projectGroup"
+        );
+        for (const groupNode of projectGroupNodes) {
+          const { x, y } = groupNode.position;
+          const w =
+            groupNode.width ??
+            (groupNode.style?.width as number | undefined) ??
+            0;
+          const h =
+            groupNode.height ??
+            (groupNode.style?.height as number | undefined) ??
+            0;
+          if (
+            position.x >= x &&
+            position.x <= x + w &&
+            position.y >= y &&
+            position.y <= y + h
+          ) {
+            const projectName = (groupNode.data as { label: string }).label;
+            await task.addProject(app, projectName);
+            new Notice(t("notices.project_assigned", { projectName }));
+            break;
+          }
+        }
+      }
 
       // Store the position so the node appears exactly at the drop point
       droppedNodePositions.current.set(taskId, position);
@@ -601,7 +702,7 @@ export default function TaskMapGraphView({
         return next;
       });
     },
-    [tasks, reactFlowInstance]
+    [tasks, reactFlowInstance, nodes, app]
   );
 
   const onDragOver = useCallback((event: React.DragEvent<HTMLDivElement>) => {
@@ -705,6 +806,8 @@ export default function TaskMapGraphView({
           onEdgeClick={onEdgeClick}
           onNodeClick={onNodeClick}
           onPaneClick={onPaneClick}
+          onNodeDrag={onNodeDrag}
+          onNodeDragStop={onNodeDragStop}
         >
           <div className="tasks-map-panels-stack">
             {embed.showPresetsPanel && (


### PR DESCRIPTION
This pull request adds support for assigning tasks to projects via drag-and-drop in the task map graph view. Now, when a user drags a task node over a project group node, the group is visually highlighted, and dropping the task into the group will assign it to that project. The changes also include user feedback via notices and localization for the new feature.