### PR TITLE
feat: multi-select nodes

### DIFF
--- a/global.css
+++ b/global.css
@@ -1939,3 +1939,24 @@ If your plugin does not need CSS, delete this file.
   opacity: 0.75;
   flex-shrink: 0;
 }
+
+/* Selection rectangle drawn while dragging */
+.react-flow__selection {
+  border-radius: calc(var(--radius-m, 8px) + 6px);
+  border: 2px dashed var(--interactive-accent);
+  background: color-mix(in srgb, var(--interactive-accent) 8%, transparent);
+}
+
+/* "At rest" bounding box around the selected nodes.
+   ReactFlow sets outline:none on :focus (fires when canvas is active), so we
+   override it back. Radius: outer = inner + gap (concentric matching). */
+.react-flow__nodesselection-rect,
+.react-flow__nodesselection-rect:focus,
+.react-flow__nodesselection-rect:focus-visible {
+  border: none;
+  border-radius: var(--radius-m, 8px);
+  background: color-mix(in srgb, var(--interactive-accent) 6%, transparent);
+  box-shadow: 0 0 0 6px color-mix(in srgb, var(--interactive-accent) 6%, transparent);
+  outline: 2px dashed var(--interactive-accent);
+  outline-offset: 6px;
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -126,7 +126,8 @@
     "cannot_create_edges_different_types": "Cannot create edges between different task types (dataview and note-based tasks). Both tasks must be of the same type."
   },
   "notices": {
-    "project_assigned": "Added to project: {{projectName}}"
+    "project_assigned": "Added to project: {{projectName}}",
+    "project_assigned_multiple": "Added {{count}} tasks to project: {{projectName}}"
   },
   "presets": {
     "panel_title": "Saved Filters",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -126,7 +126,8 @@
     "cannot_create_edges_different_types": "Kan geen verbindingen maken tussen verschillende taaktypes (dataview en notitie-gebaseerde taken). Beide taken moeten van hetzelfde type zijn."
   },
   "notices": {
-    "project_assigned": "Toegevoegd aan project: {{projectName}}"
+    "project_assigned": "Toegevoegd aan project: {{projectName}}",
+    "project_assigned_multiple": "{{count}} taken toegevoegd aan project: {{projectName}}"
   },
   "presets": {
     "panel_title": "Opgeslagen filters",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -126,7 +126,8 @@
     "cannot_create_edges_different_types": "无法在不同任务类型（dataview 和基于笔记的任务）之间创建连接。两个任务必须是相同类型。"
   },
   "notices": {
-    "project_assigned": "已添加到项目：{{projectName}}"
+    "project_assigned": "已添加到项目：{{projectName}}",
+    "project_assigned_multiple": "已将 {{count}} 个任务添加到项目：{{projectName}}"
   },
   "presets": {
     "panel_title": "已保存的筛选器",

--- a/src/views/TaskMapGraphView.tsx
+++ b/src/views/TaskMapGraphView.tsx
@@ -6,6 +6,7 @@ import ReactFlow, {
   addEdge,
   useReactFlow,
   type NodeDragHandler,
+  type SelectionDragHandler,
 } from "reactflow";
 import { Notice } from "obsidian";
 import { useApp } from "src/hooks/hooks";
@@ -596,16 +597,16 @@ export default function TaskMapGraphView({
     [nodes]
   );
 
-  // Highlight project group node while a task node is dragged over it
-  const onNodeDrag: NodeDragHandler = useCallback(
-    (_event, draggedNode) => {
-      if (draggedNode.type !== "task") return;
-      const dragPos = draggedNode.positionAbsolute ?? draggedNode.position;
-      const hoveredGroupId = findGroupAtPosition(dragPos);
+  // Update isDragOver highlights for project group nodes based on a set of drag positions
+  const updateDragOverHighlights = useCallback(
+    (positions: { x: number; y: number }[]) => {
+      const hoveredGroupIds = new Set(
+        positions.map((pos) => findGroupAtPosition(pos)).filter(Boolean)
+      );
       setNodes((nds) =>
         nds.map((n) => {
           if (n.type !== "projectGroup") return n;
-          const isDragOver = n.id === hoveredGroupId;
+          const isDragOver = hoveredGroupIds.has(n.id);
           if ((n.data as { isDragOver?: boolean }).isDragOver === isDragOver)
             return n;
           return { ...n, data: { ...n.data, isDragOver } };
@@ -615,33 +616,107 @@ export default function TaskMapGraphView({
     [findGroupAtPosition, setNodes]
   );
 
+  // Highlight project group node while a task node is dragged over it
+  const onNodeDrag: NodeDragHandler = useCallback(
+    (_event, draggedNode) => {
+      if (draggedNode.type !== "task") return;
+      const dragPos = draggedNode.positionAbsolute ?? draggedNode.position;
+      updateDragOverHighlights([dragPos]);
+    },
+    [updateDragOverHighlights]
+  );
+
+  // Highlight project group nodes while multiple selected task nodes are dragged
+  const onSelectionDrag: SelectionDragHandler = useCallback(
+    (_event, draggedNodes) => {
+      const positions = draggedNodes
+        .filter((n) => n.type === "task")
+        .map((n) => n.positionAbsolute ?? n.position);
+      updateDragOverHighlights(positions);
+    },
+    [updateDragOverHighlights]
+  );
+
+  // Clear all drag-over highlights on project group nodes
+  const clearDragOverHighlights = useCallback(() => {
+    setNodes((nds) =>
+      nds.map((n) => {
+        if (n.type !== "projectGroup") return n;
+        if (!(n.data as { isDragOver?: boolean }).isDragOver) return n;
+        return { ...n, data: { ...n.data, isDragOver: false } };
+      })
+    );
+  }, [setNodes]);
+
+  // Assign a list of task nodes to the project group they were dropped into
+  const assignDraggedNodesToProject = useCallback(
+    async (
+      draggedNodes: {
+        id: string;
+        type?: string;
+        position: { x: number; y: number };
+        positionAbsolute?: { x: number; y: number };
+      }[]
+    ) => {
+      const taskNodes = draggedNodes.filter((n) => n.type === "task");
+      if (taskNodes.length === 0) return;
+
+      // Group task nodes by their target project group
+      const assignmentMap = new Map<string, string>(); // taskId -> projectName
+      for (const draggedNode of taskNodes) {
+        const dragPos = draggedNode.positionAbsolute ?? draggedNode.position;
+        const groupId = findGroupAtPosition(dragPos);
+        if (!groupId) continue;
+        const groupNode = nodes.find((n) => n.id === groupId);
+        if (!groupNode) continue;
+        const projectName = (groupNode.data as { label: string }).label;
+        assignmentMap.set(draggedNode.id, projectName);
+      }
+
+      if (assignmentMap.size === 0) return;
+
+      // Perform assignments
+      const projectCounts = new Map<string, number>();
+      for (const [taskId, projectName] of assignmentMap) {
+        const task = tasks.find((t) => t.id === taskId);
+        if (!(task instanceof NoteTask)) continue;
+        await task.addProject(app, projectName);
+        projectCounts.set(
+          projectName,
+          (projectCounts.get(projectName) ?? 0) + 1
+        );
+      }
+
+      // Show a notice per project
+      for (const [projectName, count] of projectCounts) {
+        if (count === 1) {
+          new Notice(t("notices.project_assigned", { projectName }));
+        } else {
+          new Notice(
+            t("notices.project_assigned_multiple", { projectName, count })
+          );
+        }
+      }
+    },
+    [tasks, nodes, app, findGroupAtPosition]
+  );
+
   // Handle drag-stop of a graph task node — assign to project if dropped inside a group
   const onNodeDragStop: NodeDragHandler = useCallback(
     async (_event, draggedNode) => {
-      // Clear all drag-over highlights
-      setNodes((nds) =>
-        nds.map((n) => {
-          if (n.type !== "projectGroup") return n;
-          if (!(n.data as { isDragOver?: boolean }).isDragOver) return n;
-          return { ...n, data: { ...n.data, isDragOver: false } };
-        })
-      );
-
-      if (draggedNode.type !== "task") return;
-      const task = tasks.find((t) => t.id === draggedNode.id);
-      if (!(task instanceof NoteTask)) return;
-
-      const dragPos = draggedNode.positionAbsolute ?? draggedNode.position;
-      const groupId = findGroupAtPosition(dragPos);
-      if (!groupId) return;
-
-      const groupNode = nodes.find((n) => n.id === groupId);
-      if (!groupNode) return;
-      const projectName = (groupNode.data as { label: string }).label;
-      await task.addProject(app, projectName);
-      new Notice(t("notices.project_assigned", { projectName }));
+      clearDragOverHighlights();
+      await assignDraggedNodesToProject([draggedNode]);
     },
-    [tasks, nodes, app, findGroupAtPosition, setNodes]
+    [clearDragOverHighlights, assignDraggedNodesToProject]
+  );
+
+  // Handle drag-stop of a multi-node selection — assign all task nodes to projects
+  const onSelectionDragStop: SelectionDragHandler = useCallback(
+    async (_event, draggedNodes) => {
+      clearDragOverHighlights();
+      await assignDraggedNodesToProject(draggedNodes);
+    },
+    [clearDragOverHighlights, assignDraggedNodesToProject]
   );
 
   // Handle drop of an unlinked task from the sidebar onto the graph canvas
@@ -808,6 +883,10 @@ export default function TaskMapGraphView({
           onPaneClick={onPaneClick}
           onNodeDrag={onNodeDrag}
           onNodeDragStop={onNodeDragStop}
+          onSelectionDrag={onSelectionDrag}
+          onSelectionDragStop={onSelectionDragStop}
+          multiSelectionKeyCode="Shift"
+          selectionKeyCode="Shift"
         >
           <div className="tasks-map-panels-stack">
             {embed.showPresetsPanel && (

--- a/src/views/TaskMapGraphView.tsx
+++ b/src/views/TaskMapGraphView.tsx
@@ -648,7 +648,9 @@ export default function TaskMapGraphView({
     );
   }, [setNodes]);
 
-  // Assign a list of task nodes to the project group they were dropped into
+  // Assign a list of task nodes to the project group they were dropped into.
+  // For a multi-node selection, any single node overlapping a group is enough
+  // to assign the entire selection to that group.
   const assignDraggedNodesToProject = useCallback(
     async (
       draggedNodes: {
@@ -661,41 +663,40 @@ export default function TaskMapGraphView({
       const taskNodes = draggedNodes.filter((n) => n.type === "task");
       if (taskNodes.length === 0) return;
 
-      // Group task nodes by their target project group
-      const assignmentMap = new Map<string, string>(); // taskId -> projectName
+      // Find the first group that any dragged node overlaps
+      let targetProjectName: string | null = null;
       for (const draggedNode of taskNodes) {
         const dragPos = draggedNode.positionAbsolute ?? draggedNode.position;
         const groupId = findGroupAtPosition(dragPos);
         if (!groupId) continue;
         const groupNode = nodes.find((n) => n.id === groupId);
         if (!groupNode) continue;
-        const projectName = (groupNode.data as { label: string }).label;
-        assignmentMap.set(draggedNode.id, projectName);
+        targetProjectName = (groupNode.data as { label: string }).label;
+        break;
       }
 
-      if (assignmentMap.size === 0) return;
+      if (!targetProjectName) return;
 
-      // Perform assignments
-      const projectCounts = new Map<string, number>();
-      for (const [taskId, projectName] of assignmentMap) {
-        const task = tasks.find((t) => t.id === taskId);
+      // Assign all task nodes in the selection to that project
+      let count = 0;
+      for (const draggedNode of taskNodes) {
+        const task = tasks.find((t) => t.id === draggedNode.id);
         if (!(task instanceof NoteTask)) continue;
-        await task.addProject(app, projectName);
-        projectCounts.set(
-          projectName,
-          (projectCounts.get(projectName) ?? 0) + 1
-        );
+        await task.addProject(app, targetProjectName);
+        count++;
       }
 
-      // Show a notice per project
-      for (const [projectName, count] of projectCounts) {
-        if (count === 1) {
-          new Notice(t("notices.project_assigned", { projectName }));
-        } else {
-          new Notice(
-            t("notices.project_assigned_multiple", { projectName, count })
-          );
-        }
+      if (count === 1) {
+        new Notice(
+          t("notices.project_assigned", { projectName: targetProjectName })
+        );
+      } else if (count > 1) {
+        new Notice(
+          t("notices.project_assigned_multiple", {
+            projectName: targetProjectName,
+            count,
+          })
+        );
       }
     },
     [tasks, nodes, app, findGroupAtPosition]


### PR DESCRIPTION
This pull request enhances the drag-and-drop functionality within the task map graph, allowing users to assign multiple selected task nodes to a project group at once. It also improves the visual feedback during drag operations and adds support for multi-task assignment notices in several languages. 

Multi-select using an area is now done using shift+left-click to create a selection.