### PR TITLE
fix: release with attestation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,6 +67,8 @@ jobs:
     needs: version
     permissions:
       contents: write
+      attestations: write
+      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -97,6 +99,14 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            main.js
+            manifest.json
+            styles.css
 
       - name: Create release commit and tag
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,6 +69,7 @@ jobs:
       contents: write
       attestations: write
       id-token: write
+      artifact-metadata: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -101,7 +102,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest@v4
         with:
           subject-path: |
             main.js


### PR DESCRIPTION
This pull request updates the release workflow to improve security and traceability by adding build provenance attestation. The changes ensure that the release process generates and attaches provenance information for key build artifacts, and grants the necessary permissions for this step.


This is in line with the new guidelines coming from https://community.obsidian.md