### PR TITLE
fix: improve styling logic upon dragging in project

### DIFF
--- a/src/views/TaskMapGraphView.tsx
+++ b/src/views/TaskMapGraphView.tsx
@@ -597,11 +597,18 @@ export default function TaskMapGraphView({
     [nodes]
   );
 
-  // Update isDragOver highlights for project group nodes based on a set of drag positions
+  // Update isDragOver highlights for project group nodes based on a set of drag positions.
+  // Groups whose IDs appear in excludeGroupIds are never highlighted (used to suppress
+  // highlighting the group a node already belongs to).
   const updateDragOverHighlights = useCallback(
-    (positions: { x: number; y: number }[]) => {
+    (
+      positions: { x: number; y: number }[],
+      excludeGroupIds: Set<string> = new Set()
+    ) => {
       const hoveredGroupIds = new Set(
-        positions.map((pos) => findGroupAtPosition(pos)).filter(Boolean)
+        positions
+          .map((pos) => findGroupAtPosition(pos))
+          .filter((id): id is string => id !== null && !excludeGroupIds.has(id))
       );
       setNodes((nds) =>
         nds.map((n) => {
@@ -621,7 +628,10 @@ export default function TaskMapGraphView({
     (_event, draggedNode) => {
       if (draggedNode.type !== "task") return;
       const dragPos = draggedNode.positionAbsolute ?? draggedNode.position;
-      updateDragOverHighlights([dragPos]);
+      const excludeGroupIds = new Set(
+        draggedNode.parentNode ? [draggedNode.parentNode] : []
+      );
+      updateDragOverHighlights([dragPos], excludeGroupIds);
     },
     [updateDragOverHighlights]
   );
@@ -629,10 +639,12 @@ export default function TaskMapGraphView({
   // Highlight project group nodes while multiple selected task nodes are dragged
   const onSelectionDrag: SelectionDragHandler = useCallback(
     (_event, draggedNodes) => {
-      const positions = draggedNodes
-        .filter((n) => n.type === "task")
-        .map((n) => n.positionAbsolute ?? n.position);
-      updateDragOverHighlights(positions);
+      const taskNodes = draggedNodes.filter((n) => n.type === "task");
+      const positions = taskNodes.map((n) => n.positionAbsolute ?? n.position);
+      const excludeGroupIds = new Set(
+        taskNodes.map((n) => n.parentNode).filter((id): id is string => !!id)
+      );
+      updateDragOverHighlights(positions, excludeGroupIds);
     },
     [updateDragOverHighlights]
   );


### PR DESCRIPTION
This pull request refines the drag-and-drop highlighting behavior in the `TaskMapGraphView` to prevent project group nodes from being highlighted when a task is dragged over its current group. The main improvements ensure that groups a node already belongs to are excluded from drag-over highlighting, resulting in a more intuitive user experience.