### PR TITLE
style: reduce usage of `important`

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -4,6 +4,8 @@
     "no-duplicate-selectors": true,
     "shorthand-property-no-redundant-values": true,
     "declaration-block-no-shorthand-property-overrides": true,
-    "no-invalid-double-slash-comments": true
+    "no-invalid-double-slash-comments": true,
+    "declaration-no-important": true,
+    "selector-class-pattern": "^(tasks-map-|react-flow|theme-dark)[a-z0-9_-]*(__|--[a-z0-9_-]+)?$"
   }
 }

--- a/global.css
+++ b/global.css
@@ -103,7 +103,7 @@ If your plugin does not need CSS, delete this file.
 }
 
 /* Link Button Styles */
-.tasks-map-link-button {
+.tasks-map-graph-container .tasks-map-link-button {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -111,11 +111,11 @@ If your plugin does not need CSS, delete this file.
   padding: 0 10px;
   appearance: none;
   -webkit-appearance: none;
-  border: none !important;
-  border-left: 1px solid var(--tasks-map-node-divider) !important;
-  border-radius: 0 !important;
-  box-shadow: none !important;
-  background: transparent !important;
+  border: none;
+  border-left: 1px solid var(--tasks-map-node-divider);
+  border-radius: 0;
+  box-shadow: none;
+  background: transparent;
   cursor: pointer;
   flex-shrink: 0;
   color: var(--text-muted);
@@ -135,8 +135,8 @@ If your plugin does not need CSS, delete this file.
   color: var(--text-muted);
 }
 
-.tasks-map-link-button:hover {
-  background: var(--tasks-map-node-hover) !important;
+.tasks-map-graph-container .tasks-map-link-button:hover {
+  background: var(--tasks-map-node-hover);
 }
 
 /* Task Menu Styles */
@@ -147,7 +147,7 @@ If your plugin does not need CSS, delete this file.
   align-self: stretch;
 }
 
-.tasks-map-task-menu-button {
+.tasks-map-graph-container .tasks-map-task-menu-button {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -155,11 +155,11 @@ If your plugin does not need CSS, delete this file.
   padding: 0 10px;
   appearance: none;
   -webkit-appearance: none;
-  border: none !important;
-  border-left: 1px solid var(--tasks-map-node-divider) !important;
-  border-radius: 0 var(--radius-m) 0 0 !important;
-  box-shadow: none !important;
-  background: transparent !important;
+  border: none;
+  border-left: 1px solid var(--tasks-map-node-divider);
+  border-radius: 0 var(--radius-m) 0 0;
+  box-shadow: none;
+  background: transparent;
   cursor: pointer;
   flex-shrink: 0;
   color: var(--text-muted);
@@ -167,8 +167,8 @@ If your plugin does not need CSS, delete this file.
   outline: none;
 }
 
-.tasks-map-task-menu-button:hover {
-  background: var(--tasks-map-node-hover) !important;
+.tasks-map-graph-container .tasks-map-task-menu-button:hover {
+  background: var(--tasks-map-node-hover);
   color: var(--text-normal);
 }
 
@@ -253,7 +253,7 @@ If your plugin does not need CSS, delete this file.
   margin-bottom: 6px;
 }
 
-.tasks-map-task-node-header-button {
+.tasks-map-graph-container .tasks-map-task-node-header-button {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -261,11 +261,11 @@ If your plugin does not need CSS, delete this file.
   padding: 0 10px;
   appearance: none;
   -webkit-appearance: none;
-  border: none !important;
-  border-left: 1px solid var(--tasks-map-node-divider) !important;
-  border-radius: 0 !important;
-  box-shadow: none !important;
-  background: var(--tasks-map-node-bg) !important;
+  border: none;
+  border-left: 1px solid var(--tasks-map-node-divider);
+  border-radius: 0;
+  box-shadow: none;
+  background: var(--tasks-map-node-bg);
   cursor: pointer;
   flex-shrink: 0;
   color: var(--text-muted);
@@ -274,11 +274,11 @@ If your plugin does not need CSS, delete this file.
   transition: color 0.2s ease;
 }
 
-.tasks-map-task-node-header-button:hover {
-  background: var(--tasks-map-node-hover) !important;
+.tasks-map-graph-container .tasks-map-task-node-header-button:hover {
+  background: var(--tasks-map-node-hover);
 }
 
-.tasks-map-star-button {
+.tasks-map-graph-container .tasks-map-star-button {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -286,11 +286,11 @@ If your plugin does not need CSS, delete this file.
   padding: 0 10px;
   appearance: none;
   -webkit-appearance: none;
-  border: none !important;
-  border-left: 1px solid var(--tasks-map-node-divider) !important;
-  border-radius: 0 !important;
-  box-shadow: none !important;
-  background: transparent !important;
+  border: none;
+  border-left: 1px solid var(--tasks-map-node-divider);
+  border-radius: 0;
+  box-shadow: none;
+  background: transparent;
   cursor: pointer;
   flex-shrink: 0;
   color: var(--text-muted);
@@ -300,8 +300,8 @@ If your plugin does not need CSS, delete this file.
   transition: color 0.2s ease;
 }
 
-.tasks-map-star-button:hover {
-  background: var(--tasks-map-node-hover) !important;
+.tasks-map-graph-container .tasks-map-star-button:hover {
+  background: var(--tasks-map-node-hover);
   color: rgb(255, 215, 0);
 }
 
@@ -716,30 +716,30 @@ If your plugin does not need CSS, delete this file.
   padding: 10px 12px;
 }
 
-.tasks-map-filter-panel__header-icon {
+.tasks-map-graph-container .tasks-map-filter-panel__header-icon {
   display: flex;
   align-items: center;
   align-self: stretch;
   padding: 0 10px;
   appearance: none;
   -webkit-appearance: none;
-  border: none !important;
-  border-left: 1px solid var(--background-modifier-border) !important;
-  border-radius: 0 !important;
-  box-shadow: none !important;
-  background: var(--background-secondary) !important;
+  border: none;
+  border-left: 1px solid var(--background-modifier-border);
+  border-radius: 0;
+  box-shadow: none;
+  background: var(--background-secondary);
   cursor: pointer;
   flex-shrink: 0;
   color: var(--text-muted);
   height: auto;
 }
 
-.tasks-map-filter-panel__header-icon:hover {
-  background: var(--background-modifier-hover) !important;
+.tasks-map-graph-container .tasks-map-filter-panel__header-icon:hover {
+  background: var(--background-modifier-hover);
 }
 
-.tasks-map-filter-panel.minimized .tasks-map-filter-panel__header-icon {
-  border-radius: 0 8px 8px 0 !important;
+.tasks-map-graph-container .tasks-map-filter-panel.minimized .tasks-map-filter-panel__header-icon {
+  border-radius: 0 8px 8px 0;
   padding: 10px;
 }
 
@@ -833,15 +833,15 @@ If your plugin does not need CSS, delete this file.
   gap: 6px;
 }
 
-.tasks-map-search-icon-button {
+.tasks-map-graph-container .tasks-map-search-icon-button {
   display: flex;
   align-items: center;
   justify-content: center;
   appearance: none;
   -webkit-appearance: none;
-  background: transparent !important;
-  border: none !important;
-  box-shadow: none !important;
+  background: transparent;
+  border: none;
+  box-shadow: none;
   color: var(--text-muted);
   cursor: pointer;
   padding: 0;
@@ -853,19 +853,19 @@ If your plugin does not need CSS, delete this file.
   min-height: 28px;
 }
 
-.tasks-map-search-icon-button:hover {
+.tasks-map-graph-container .tasks-map-search-icon-button:hover {
   color: var(--text-normal);
-  background: var(--background-modifier-hover) !important;
-  box-shadow: none !important;
+  background: var(--background-modifier-hover);
+  box-shadow: none;
 }
 
-.tasks-map-search-input {
+.tasks-map-graph-container .tasks-map-search-input {
   flex: 1;
-  border: 1px solid var(--background-modifier-border) !important;
-  background: var(--background-primary) !important;
-  color: var(--text-normal) !important;
-  font-size: 13px !important;
-  padding: 6px 8px !important;
+  border: 1px solid var(--background-modifier-border);
+  background: var(--background-primary);
+  color: var(--text-normal);
+  font-size: 13px;
+  padding: 6px 8px;
   outline: none;
   min-width: 0;
   border-radius: 4px;
@@ -877,15 +877,15 @@ If your plugin does not need CSS, delete this file.
   color: var(--text-faint);
 }
 
-.tasks-map-search-clear {
+.tasks-map-graph-container .tasks-map-search-clear {
   display: flex;
   align-items: center;
   justify-content: center;
   appearance: none;
   -webkit-appearance: none;
-  background: transparent !important;
-  border: none !important;
-  box-shadow: none !important;
+  background: transparent;
+  border: none;
+  box-shadow: none;
   color: var(--text-muted);
   cursor: pointer;
   padding: 0;
@@ -897,10 +897,10 @@ If your plugin does not need CSS, delete this file.
   min-height: 28px;
 }
 
-.tasks-map-search-clear:hover {
+.tasks-map-graph-container .tasks-map-search-clear:hover {
   color: var(--text-normal);
-  background: transparent !important;
-  box-shadow: none !important;
+  background: transparent;
+  box-shadow: none;
 }
 
 .tasks-map-search-result-count {
@@ -1006,7 +1006,7 @@ If your plugin does not need CSS, delete this file.
   font-size: 12px;
 }
 
-.tasks-map-gui-overlay-reload-button {
+.tasks-map-graph-container .tasks-map-gui-overlay-reload-button {
   width: 100%;
   padding: 6px 10px;
   border-radius: 4px;
@@ -1014,17 +1014,17 @@ If your plugin does not need CSS, delete this file.
   font-weight: 500;
   appearance: none;
   -webkit-appearance: none;
-  background: transparent !important;
-  box-shadow: none !important;
+  background: transparent;
+  box-shadow: none;
   color: var(--text-faint);
-  border: none !important;
+  border: none;
   cursor: pointer;
 }
 
-.tasks-map-gui-overlay-reload-button:hover {
+.tasks-map-graph-container .tasks-map-gui-overlay-reload-button:hover {
   color: var(--text-muted);
-  background: var(--background-modifier-hover) !important;
-  box-shadow: none !important;
+  background: var(--background-modifier-hover);
+  box-shadow: none;
 }
 
 /* Legacy styles - kept for backward compatibility */
@@ -1182,10 +1182,10 @@ If your plugin does not need CSS, delete this file.
 
 /* Task Minimap Styles */
 .tasks-map-react-flow__minimap {
-  background: var(--background-primary) !important;
-  border-radius: 8px !important;
-  overflow: hidden !important;
-  box-shadow: 0 2px 8px rgba(var(--tasks-map-color-black), 0.12) !important;
+  background: var(--background-primary);
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 2px 8px rgba(var(--tasks-map-color-black), 0.12);
 }
 
 /* Task Map Graph View Styles */
@@ -1592,30 +1592,30 @@ If your plugin does not need CSS, delete this file.
   padding: 10px 12px;
 }
 
-.tasks-map-unlinked-panel__header-icon {
+.tasks-map-graph-container .tasks-map-unlinked-panel__header-icon {
   display: flex;
   align-items: center;
   align-self: stretch;
   padding: 0 10px;
   appearance: none;
   -webkit-appearance: none;
-  border: none !important;
-  border-left: 1px solid var(--background-modifier-border) !important;
-  border-radius: 0 !important;
-  box-shadow: none !important;
-  background: var(--background-secondary) !important;
+  border: none;
+  border-left: 1px solid var(--background-modifier-border);
+  border-radius: 0;
+  box-shadow: none;
+  background: var(--background-secondary);
   cursor: pointer;
   flex-shrink: 0;
   color: var(--text-muted);
   height: auto;
 }
 
-.tasks-map-unlinked-panel__header-icon:hover {
-  background: var(--background-modifier-hover) !important;
+.tasks-map-graph-container .tasks-map-unlinked-panel__header-icon:hover {
+  background: var(--background-modifier-hover);
 }
 
-.tasks-map-unlinked-panel--collapsed .tasks-map-unlinked-panel__header-icon {
-  border-radius: 0 8px 8px 0 !important;
+.tasks-map-graph-container .tasks-map-unlinked-panel--collapsed .tasks-map-unlinked-panel__header-icon {
+  border-radius: 0 8px 8px 0;
   padding: 10px;
 }
 
@@ -1633,14 +1633,14 @@ If your plugin does not need CSS, delete this file.
   flex-shrink: 0;
 }
 
-.tasks-map-unlinked-panel__filter-input {
+.tasks-map-graph-container .tasks-map-unlinked-panel__filter-input {
   flex: 1;
-  background: var(--background-primary) !important;
-  border: 1px solid var(--background-modifier-border) !important;
+  background: var(--background-primary);
+  border: 1px solid var(--background-modifier-border);
   border-radius: 5px;
   padding: 4px 8px;
   font-size: 12px;
-  color: var(--text-normal) !important;
+  color: var(--text-normal);
   outline: none;
   min-width: 0;
 }
@@ -1742,15 +1742,15 @@ If your plugin does not need CSS, delete this file.
   flex-shrink: 0;
 }
 
-.tasks-map-preset-action-btn {
+.tasks-map-graph-container .tasks-map-preset-action-btn {
   display: flex;
   align-items: center;
   justify-content: center;
   appearance: none;
   -webkit-appearance: none;
-  background: transparent !important;
-  border: none !important;
-  box-shadow: none !important;
+  background: transparent;
+  border: none;
+  box-shadow: none;
   padding: 0;
   width: 38px;
   height: 38px;
@@ -1762,15 +1762,15 @@ If your plugin does not need CSS, delete this file.
   flex-shrink: 0;
 }
 
-.tasks-map-preset-action-btn:hover {
+.tasks-map-graph-container .tasks-map-preset-action-btn:hover {
   color: var(--text-normal);
-  background: var(--background-modifier-hover) !important;
-  box-shadow: none !important;
+  background: var(--background-modifier-hover);
+  box-shadow: none;
 }
 
-.tasks-map-preset-action-btn--danger:hover {
+.tasks-map-graph-container .tasks-map-preset-action-btn--danger:hover {
   color: var(--text-error);
-  background: rgba(var(--tasks-map-color-red-rgb), 0.12) !important;
+  background: rgba(var(--tasks-map-color-red-rgb), 0.12);
 }
 
 .tasks-map-preset-action-btn:disabled {
@@ -1804,14 +1804,14 @@ If your plugin does not need CSS, delete this file.
   color: var(--text-faint);
 }
 
-.tasks-map-preset-save-btn {
+.tasks-map-graph-container .tasks-map-preset-save-btn {
   width: 100%;
   padding: 6px 10px;
   appearance: none;
   -webkit-appearance: none;
-  background: transparent !important;
-  box-shadow: none !important;
-  border: none !important;
+  background: transparent;
+  box-shadow: none;
+  border: none;
   border-radius: 4px;
   font-size: 12px;
   color: var(--text-faint);
@@ -1819,10 +1819,10 @@ If your plugin does not need CSS, delete this file.
   text-align: center;
 }
 
-.tasks-map-preset-save-btn:hover {
+.tasks-map-graph-container .tasks-map-preset-save-btn:hover {
   color: var(--text-muted);
-  background: var(--background-modifier-hover) !important;
-  box-shadow: none !important;
+  background: var(--background-modifier-hover);
+  box-shadow: none;
 }
 
 /* Presets Panel */
@@ -1867,30 +1867,30 @@ If your plugin does not need CSS, delete this file.
   padding: 10px 12px;
 }
 
-.tasks-map-presets-panel__header-icon {
+.tasks-map-graph-container .tasks-map-presets-panel__header-icon {
   display: flex;
   align-items: center;
   align-self: stretch;
   padding: 0 10px;
   appearance: none;
   -webkit-appearance: none;
-  border: none !important;
-  border-left: 1px solid var(--background-modifier-border) !important;
-  border-radius: 0 !important;
-  box-shadow: none !important;
-  background: var(--background-secondary) !important;
+  border: none;
+  border-left: 1px solid var(--background-modifier-border);
+  border-radius: 0;
+  box-shadow: none;
+  background: var(--background-secondary);
   cursor: pointer;
   flex-shrink: 0;
   color: var(--text-muted);
   height: auto;
 }
 
-.tasks-map-presets-panel__header-icon:hover {
-  background: var(--background-modifier-hover) !important;
+.tasks-map-graph-container .tasks-map-presets-panel__header-icon:hover {
+  background: var(--background-modifier-hover);
 }
 
-.tasks-map-presets-panel--collapsed .tasks-map-presets-panel__header-icon {
-  border-radius: 0 8px 8px 0 !important;
+.tasks-map-graph-container .tasks-map-presets-panel--collapsed .tasks-map-presets-panel__header-icon {
+  border-radius: 0 8px 8px 0;
   padding: 10px;
 }
 

--- a/global.css
+++ b/global.css
@@ -327,7 +327,7 @@ If your plugin does not need CSS, delete this file.
 }
 
 /* Task Details Styles */
-.task-details {
+.tasks-map-task-details {
   margin-top: 10px;
   font-size: 13px;
   background: var(--background-secondary-alt);
@@ -403,13 +403,12 @@ If your plugin does not need CSS, delete this file.
 .tasks-map-tag--mono-6,
 .tasks-map-tag--mono-7 { background-color: #2674b5; }
 
-.tasks-map-graph-container.hide-tags .task-tag,
-.tasks-map-graph-container.hide-tags .task-tags-container,
-.tasks-map-graph-container.hide-tags .tasks-map-task-node-footer {
-  display: none !important;
+.tasks-map-graph-container.tasks-map--hide-tags .tasks-map-tag-list,
+.tasks-map-graph-container.tasks-map--hide-tags .tasks-map-task-node-footer {
+  display: none;
 }
 
-.tasks-map-tag.removable {
+.tasks-map-tag.tasks-map-tag--removable {
   cursor: pointer;
 }
 
@@ -429,106 +428,106 @@ If your plugin does not need CSS, delete this file.
 
 /* Tag Input (CreatableSelect) Styles */
 .tasks-map-tag-select__container {
-  min-width: 160px !important;
-  font-size: 11px !important;
+  min-width: 160px;
+  font-size: 11px;
 }
 
 .tasks-map-tag-select__control {
-  min-height: 20px !important;
-  height: 20px !important;
-  min-width: 160px !important;
-  background: var(--background-primary) !important;
-  color: var(--text-normal) !important;
-  border-color: var(--interactive-accent) !important;
-  border-radius: 12px !important;
-  box-shadow: 0 0 0 1px var(--interactive-accent) !important;
+  min-height: 20px;
+  height: 20px;
+  min-width: 160px;
+  background: var(--background-primary);
+  color: var(--text-normal);
+  border-color: var(--interactive-accent);
+  border-radius: 12px;
+  box-shadow: 0 0 0 1px var(--interactive-accent);
 }
 
 .tasks-map-tag-select__control:hover {
-  border-color: var(--interactive-accent) !important;
+  border-color: var(--interactive-accent);
 }
 
 .tasks-map-tag-select-error .tasks-map-tag-select__control {
-  background: rgba(255, 0, 0, 0.1) !important;
-  border-color: var(--text-error) !important;
-  box-shadow: 0 0 0 1px var(--text-error) !important;
+  background: rgba(255, 0, 0, 0.1);
+  border-color: var(--text-error);
+  box-shadow: 0 0 0 1px var(--text-error);
 }
 
 .tasks-map-tag-select-error .tasks-map-tag-select__control:hover {
-  border-color: var(--text-error) !important;
+  border-color: var(--text-error);
 }
 
 .tasks-map-tag-select__value-container {
-  padding: 0 8px !important;
-  height: 100% !important;
-  box-sizing: border-box !important;
-  display: flex !important;
-  align-items: center !important;
+  padding: 0 8px;
+  height: 100%;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
 }
 
 .tasks-map-tag-select__indicators {
-  display: none !important;
+  display: none;
 }
 
 .tasks-map-tag-select__input {
-  margin: 0 !important;
-  padding: 0 !important;
-  border: none !important;
-  outline: none !important;
-  box-shadow: none !important;
-  background: transparent !important;
-  flex: 1 !important;
-  display: flex !important;
-  align-items: center !important;
+  margin: 0;
+  padding: 0;
+  border: none;
+  outline: none;
+  box-shadow: none;
+  background: transparent;
+  flex: 1;
+  display: flex;
+  align-items: center;
 }
 
 .tasks-map-tag-select__input > div {
-  margin: 0 !important;
-  padding: 0 !important;
-  border: none !important;
-  outline: none !important;
-  box-shadow: none !important;
-  background: transparent !important;
-  flex: 1 !important;
-  display: flex !important;
-  align-items: center !important;
-  font-size: 11px !important;
+  margin: 0;
+  padding: 0;
+  border: none;
+  outline: none;
+  box-shadow: none;
+  background: transparent;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  font-size: 11px;
 }
 
 .tasks-map-tag-select__input input,
 .tasks-map-tag-select__input input:focus {
-  margin: 0 !important;
-  padding: 0 !important;
-  color: var(--text-normal) !important;
-  font-size: 11px !important;
-  font-family: inherit !important;
-  line-height: 11px !important;
-  border: none !important;
-  outline: none !important;
-  box-shadow: none !important;
-  background: transparent !important;
-  flex: 1 !important;
-  min-width: 4px !important;
-  -webkit-text-size-adjust: 100% !important;
-  text-size-adjust: 100% !important;
+  margin: 0;
+  padding: 0;
+  color: var(--text-normal);
+  font-size: 11px;
+  font-family: inherit;
+  line-height: 11px;
+  border: none;
+  outline: none;
+  box-shadow: none;
+  background: transparent;
+  flex: 1;
+  min-width: 4px;
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
 }
 
 .tasks-map-tag-select__single-value {
-  margin: 0 !important;
-  padding: 0 !important;
-  color: var(--text-normal) !important;
-  font-size: 11px !important;
-  font-family: inherit !important;
-  line-height: 11px !important;
+  margin: 0;
+  padding: 0;
+  color: var(--text-normal);
+  font-size: 11px;
+  font-family: inherit;
+  line-height: 11px;
 }
 
 .tasks-map-tag-select__placeholder {
-  color: var(--text-faint) !important;
-  font-size: 11px !important;
-  font-family: inherit !important;
-  line-height: 11px !important;
-  margin: 0 !important;
-  padding: 0 !important;
+  color: var(--text-faint);
+  font-size: 11px;
+  font-family: inherit;
+  line-height: 11px;
+  margin: 0;
+  padding: 0;
 }
 
 /* Ensure all nested elements inherit small font size */
@@ -537,49 +536,49 @@ If your plugin does not need CSS, delete this file.
 .tasks-map-tag-select__value-container *,
 .tasks-map-tag-select__input *,
 .tasks-map-tag-select__input input {
-  font-size: 11px !important;
+  font-size: 11px;
 }
 
 .tasks-map-tag-select__menu {
-  min-width: 160px !important;
-  z-index: 9999 !important;
-  background: var(--background-secondary) !important;
-  color: var(--text-normal) !important;
-  border: 1px solid var(--background-modifier-border) !important;
-  border-radius: 8px !important;
-  margin-top: 4px !important;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1) !important;
+  min-width: 160px;
+  z-index: 9999;
+  background: var(--background-secondary);
+  color: var(--text-normal);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 8px;
+  margin-top: 4px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
 
 .tasks-map-tag-select__menu-list {
-  padding: 4px !important;
-  max-height: 200px !important;
+  padding: 4px;
+  max-height: 200px;
 }
 
 .tasks-map-tag-select__option {
-  background: var(--background-secondary) !important;
-  color: var(--text-normal) !important;
-  cursor: pointer !important;
-  border-radius: 4px !important;
-  padding: 6px 8px !important;
-  font-size: 11px !important;
+  background: var(--background-secondary);
+  color: var(--text-normal);
+  cursor: pointer;
+  border-radius: 4px;
+  padding: 6px 8px;
+  font-size: 11px;
 }
 
 .tasks-map-tag-select__option--is-focused {
-  background: var(--background-modifier-hover) !important;
+  background: var(--background-modifier-hover);
 }
 
 .tasks-map-tag-select__option--is-selected {
-  background: var(--background-modifier-hover) !important;
+  background: var(--background-modifier-hover);
 }
 
 .tasks-map-tag-select__option:active {
-  background: var(--background-modifier-active) !important;
+  background: var(--background-modifier-active);
 }
 
 .tasks-map-tag-select__menu-notice {
-  color: var(--text-muted) !important;
-  font-size: 11px !important;
+  color: var(--text-muted);
+  font-size: 11px;
 }
 
 .tasks-map-add-tag-button {
@@ -603,7 +602,7 @@ If your plugin does not need CSS, delete this file.
   color: white;
 }
 
-.task-tags-container {
+.tasks-map-tag-list {
   display: flex;
   align-items: flex-start;
   gap: 4px;
@@ -611,7 +610,7 @@ If your plugin does not need CSS, delete this file.
   flex-wrap: wrap;
 }
 
-.task-tags-container:hover .tasks-map-add-tag-button {
+.tasks-map-tag-list:hover .tasks-map-add-tag-button {
   opacity: 1;
 }
 
@@ -637,11 +636,11 @@ If your plugin does not need CSS, delete this file.
   text-decoration: underline;
 }
 
-.tasks-map-link.internal-link {
+.tasks-map-link.tasks-map-link--internal {
   color: var(--link-color);
 }
 
-.tasks-map-link.internal-link:hover {
+.tasks-map-link.tasks-map-link--internal:hover {
   color: var(--link-color-hover);
 }
 
@@ -686,7 +685,7 @@ If your plugin does not need CSS, delete this file.
   overflow: hidden;
 }
 
-.tasks-map-filter-panel.minimized {
+.tasks-map-filter-panel.tasks-map-filter-panel--minimized {
   min-width: unset;
   max-height: unset;
   overflow: visible;
@@ -701,7 +700,7 @@ If your plugin does not need CSS, delete this file.
   flex-shrink: 0;
 }
 
-.tasks-map-filter-panel.minimized .tasks-map-filter-panel__header {
+.tasks-map-filter-panel.tasks-map-filter-panel--minimized .tasks-map-filter-panel__header {
   border-bottom: none;
 }
 
@@ -738,7 +737,7 @@ If your plugin does not need CSS, delete this file.
   background: var(--background-modifier-hover);
 }
 
-.tasks-map-graph-container .tasks-map-filter-panel.minimized .tasks-map-filter-panel__header-icon {
+.tasks-map-graph-container .tasks-map-filter-panel.tasks-map-filter-panel--minimized .tasks-map-filter-panel__header-icon {
   border-radius: 0 8px 8px 0;
   padding: 10px;
 }
@@ -1936,12 +1935,12 @@ If your plugin does not need CSS, delete this file.
   opacity: 0.95;
 }
 
-.tasks-map-project-group.selected {
+.tasks-map-project-group.tasks-map-project-group--selected {
   border-color: var(--background-modifier-border-focus);
   box-shadow: 0 0 0 2px var(--background-modifier-border-focus);
 }
 
-.tasks-map-project-group.drag-over {
+.tasks-map-project-group.tasks-map-project-group--drag-over {
   border-color: var(--interactive-accent);
   box-shadow: 0 0 0 2px var(--interactive-accent);
   background-color: var(--background-modifier-hover);

--- a/src/components/controls-panel.tsx
+++ b/src/components/controls-panel.tsx
@@ -34,7 +34,9 @@ export default function ControlsPanel({
   };
 
   return (
-    <div className={`tasks-map-filter-panel ${isMinimized ? "minimized" : ""}`}>
+    <div
+      className={`tasks-map-filter-panel ${isMinimized ? "tasks-map-filter-panel--minimized" : ""}`}
+    >
       <div className="tasks-map-filter-panel__header">
         <span className="tasks-map-filter-panel__title">
           {t("controls.title")}

--- a/src/components/gui-overlay.tsx
+++ b/src/components/gui-overlay.tsx
@@ -133,7 +133,9 @@ export default function GuiOverlay(props: GuiOverlayProps) {
   };
 
   return (
-    <div className={`tasks-map-filter-panel ${isMinimized ? "minimized" : ""}`}>
+    <div
+      className={`tasks-map-filter-panel ${isMinimized ? "tasks-map-filter-panel--minimized" : ""}`}
+    >
       <div className="tasks-map-filter-panel__header">
         <span className="tasks-map-filter-panel__title">
           {t("filters.title")}

--- a/src/components/project-group-node.tsx
+++ b/src/components/project-group-node.tsx
@@ -13,8 +13,8 @@ export default function ProjectGroupNode({
 }: NodeProps<ProjectGroupNodeData>) {
   const classes = [
     "tasks-map-project-group",
-    selected ? "selected" : "",
-    data.isDragOver ? "drag-over" : "",
+    selected ? "tasks-map-project-group--selected" : "",
+    data.isDragOver ? "tasks-map-project-group--drag-over" : "",
   ]
     .filter(Boolean)
     .join(" ");

--- a/src/components/tag-input.tsx
+++ b/src/components/tag-input.tsx
@@ -75,6 +75,7 @@ export function TagInput({
   return (
     <CreatableSelect
       ref={selectRef}
+      unstyled
       classNamePrefix="tasks-map-tag-select"
       className={hasError || hasSpaceError ? "tasks-map-tag-select-error" : ""}
       options={options}

--- a/src/components/tag.tsx
+++ b/src/components/tag.tsx
@@ -18,7 +18,7 @@ export function Tag({ tag, palette = "rainbow", onRemove }: TagProps) {
 
   return (
     <span
-      className={`tasks-map-tag ${getTagColorClass(tag, palette)} ${onRemove ? "removable" : ""}`}
+      className={`tasks-map-tag ${getTagColorClass(tag, palette)} ${onRemove ? "tasks-map-tag--removable" : ""}`}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >

--- a/src/components/task-details.tsx
+++ b/src/components/task-details.tsx
@@ -7,7 +7,7 @@ interface TaskDetailsProps {
 
 export function TaskDetails({ task, status }: TaskDetailsProps) {
   return (
-    <div className="task-details">
+    <div className="tasks-map-task-details">
       <div>
         <b>ID:</b> {task.id}
       </div>

--- a/src/components/task-node.tsx
+++ b/src/components/task-node.tsx
@@ -218,7 +218,7 @@ export default function TaskNode({ data, selected }: NodeProps<TaskNodeData>) {
 
         {showTags && (
           <div className="tasks-map-task-node-footer">
-            <div className="task-tags-container">
+            <div className="tasks-map-tag-list">
               {tags.map((tag) => (
                 <Tag
                   key={tag}

--- a/src/hooks/use-summary-renderer.ts
+++ b/src/hooks/use-summary-renderer.ts
@@ -87,7 +87,7 @@ function renderSummaryWithLinks(
       const displayText = alias || file;
       const link = container.createEl("a", {
         text: displayText,
-        cls: "tasks-map-link internal-link",
+        cls: "tasks-map-link tasks-map-link--internal",
       });
 
       link.addEventListener("click", (e) => {

--- a/src/views/TaskMapGraphView.tsx
+++ b/src/views/TaskMapGraphView.tsx
@@ -150,9 +150,9 @@ export default function TaskMapGraphView({
   React.useEffect(() => {
     if (containerRef.current) {
       if (hideTags) {
-        containerRef.current.classList.add("hide-tags");
+        containerRef.current.classList.add("tasks-map--hide-tags");
       } else {
-        containerRef.current.classList.remove("hide-tags");
+        containerRef.current.classList.remove("tasks-map--hide-tags");
       }
     }
   }, [hideTags]);


### PR DESCRIPTION
This pull request updates the CSS for various `.tasks-map-*` components to improve scoping and maintainability. Additionally, unnecessary `!important` flags have been removed for cleaner and more maintainable code.