### PR TITLE
feat: improve UX by preserving canvas zoom on task reload and fix edge operation loss

### DIFF
--- a/global.css
+++ b/global.css
@@ -1225,6 +1225,62 @@ If your plugin does not need CSS, delete this file.
   transition: width 0.2s;
 }
 
+.tasks-map-task-node-root {
+  position: relative;
+}
+
+.tasks-map-task-date-bar {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  left: 50%;
+  z-index: 2;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 6px;
+  width: max-content;
+  max-width: 560px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--text-normal);
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
+.tasks-map-task-date-item {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: baseline;
+  gap: 4px;
+  min-height: 20px;
+  padding: 2px 9px;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 999px;
+  background: var(--background-primary);
+  box-shadow: 0 2px 6px rgba(var(--tasks-map-color-black-rgb), 0.12);
+  font-size: 11px;
+  line-height: 18px;
+  letter-spacing: 0;
+  white-space: nowrap;
+}
+
+.tasks-map-task-date-emoji {
+  font-size: 12px;
+  line-height: 1;
+}
+
+.tasks-map-task-date-label {
+  color: var(--text-muted);
+}
+
+.tasks-map-task-date-value {
+  color: var(--text-normal);
+  font-variant-numeric: tabular-nums;
+}
+
 .tasks-map-task-background--expanded {
   max-height: none;
 }

--- a/global.css
+++ b/global.css
@@ -86,11 +86,14 @@ If your plugin does not need CSS, delete this file.
   left: 50%;
   transform: translateX(-50%);
   z-index: 100;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
-.tasks-map-delete-edge-button {
+.tasks-map-delete-edge-button,
+.tasks-map-insert-task-button {
   padding: 10px;
-  background: var(--tasks-map-color-red);
   color: var(--tasks-map-color-white);
   border: none;
   border-radius: 6px;
@@ -98,8 +101,20 @@ If your plugin does not need CSS, delete this file.
   cursor: pointer;
 }
 
+.tasks-map-delete-edge-button {
+  background: var(--tasks-map-color-red);
+}
+
 .tasks-map-delete-edge-button:hover {
   background: var(--tasks-map-color-red-hover, #c53030);
+}
+
+.tasks-map-insert-task-button {
+  background: var(--interactive-accent);
+}
+
+.tasks-map-insert-task-button:hover {
+  background: var(--interactive-accent-hover);
 }
 
 /* Link Button Styles */

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "tasks-map",
     "name": "Tasks Map",
-    "version": "0.33.0",
+    "version": "0.33.1",
     "minAppVersion": "1.8.0",
     "description": "A graph view of your tasks.",
     "author": "NicoKNL",

--- a/src/components/delete-edge-button.tsx
+++ b/src/components/delete-edge-button.tsx
@@ -1,12 +1,24 @@
+import { t } from "../i18n";
+
 interface DeleteEdgeButtonProps {
   onDelete: () => void;
+  onInsertTask: () => void;
 }
 
-export const DeleteEdgeButton = ({ onDelete }: DeleteEdgeButtonProps) => {
+export const DeleteEdgeButton = ({
+  onDelete,
+  onInsertTask,
+}: DeleteEdgeButtonProps) => {
   return (
     <div className="tasks-map-delete-edge-button-container">
       <button onClick={onDelete} className="tasks-map-delete-edge-button">
-        Delete edge
+        {t("edge_actions.delete_edge")}
+      </button>
+      <button
+        onClick={onInsertTask}
+        className="tasks-map-insert-task-button"
+      >
+        {t("edge_actions.insert_task")}
       </button>
     </div>
   );

--- a/src/components/task-menu.tsx
+++ b/src/components/task-menu.tsx
@@ -8,15 +8,22 @@ import {
   deleteTaskFromVault,
   findTaskLineByIdOrText,
   getTasksApi,
+  parseTaskLine,
 } from "../lib/utils";
 
 interface TaskMenuProps {
   task: BaseTask;
   app: App;
   onTaskDeleted?: () => void;
+  onTaskEdited?: (_taskId: string, _updatedTask: BaseTask) => void;
 }
 
-const TaskMenu = ({ task, app, onTaskDeleted }: TaskMenuProps) => {
+const TaskMenu = ({
+  task,
+  app,
+  onTaskDeleted,
+  onTaskEdited,
+}: TaskMenuProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -114,6 +121,15 @@ const TaskMenu = ({ task, app, onTaskDeleted }: TaskMenuProps) => {
 
       lines[taskLineIdx] = newTaskLine;
       await vault.modify(file, lines.join("\n"));
+
+      const updatedTask = parseTaskLine(newTaskLine, task.link);
+      if (updatedTask) {
+        if (!newTaskLine.includes(updatedTask.id)) {
+          updatedTask.id = task.id;
+        }
+        updatedTask.projects = task.projects;
+        onTaskEdited?.(task.id, updatedTask);
+      }
     } catch (error) {
       console.error("Error processing task:", error);
     }

--- a/src/components/task-menu.tsx
+++ b/src/components/task-menu.tsx
@@ -6,7 +6,7 @@ import { CirclePlus, SquarePen } from "lucide-react";
 import {
   addTaskLineToVault,
   deleteTaskFromVault,
-  findTaskLineByIdOrText,
+  editTaskWithTasksModal,
   getTasksApi,
   parseTaskLine,
 } from "../lib/utils";
@@ -93,52 +93,9 @@ const TaskMenu = ({
 
     setIsOpen(false);
 
-    if (!task.link) return;
-
-    const vault = app?.vault;
-    if (!vault) return;
-
-    const file = vault.getFileByPath(task.link);
-    if (!file) return;
-
-    const tasksApi = getTasksApi(app);
-    if (!tasksApi) {
-      console.error("Tasks plugin not found or API not available");
-      return;
-    }
-
-    try {
-      const fileContent = await vault.read(file);
-      const lines = fileContent.split(/\r?\n/);
-      const taskLineIdx = findTaskLineByIdOrText(lines, task.id, task.text);
-
-      if (taskLineIdx === -1) {
-        console.warn("Task line not found");
-        return;
-      }
-
-      const taskLine = lines[taskLineIdx];
-      // console.log("before: ", taskLine);
-
-      const newTaskLine = await tasksApi.editTaskLineModal(taskLine);
-      if (!newTaskLine?.trim()) {
-        return;
-      }
-      // console.log("after: ", newTaskLine);
-
-      lines[taskLineIdx] = newTaskLine;
-      await vault.modify(file, lines.join("\n"));
-
-      const updatedTask = parseTaskLine(newTaskLine, task.link);
-      if (updatedTask) {
-        if (!newTaskLine.includes(updatedTask.id)) {
-          updatedTask.id = task.id;
-        }
-        updatedTask.projects = task.projects;
-        onTaskEdited?.(task.id, updatedTask);
-      }
-    } catch (error) {
-      console.error("Error processing task:", error);
+    const updatedTask = await editTaskWithTasksModal(task, app);
+    if (updatedTask) {
+      onTaskEdited?.(task.id, updatedTask);
     }
   };
 

--- a/src/components/task-menu.tsx
+++ b/src/components/task-menu.tsx
@@ -15,6 +15,7 @@ interface TaskMenuProps {
   task: BaseTask;
   app: App;
   onTaskDeleted?: () => void;
+  onTaskCreated?: (_newTask: BaseTask) => void;
   onTaskEdited?: (_taskId: string, _updatedTask: BaseTask) => void;
 }
 
@@ -22,6 +23,7 @@ const TaskMenu = ({
   task,
   app,
   onTaskDeleted,
+  onTaskCreated,
   onTaskEdited,
 }: TaskMenuProps) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -78,6 +80,11 @@ const TaskMenu = ({
     // It's just a string containing the Markdown for the task.
     // console.log(taskLine);
     await addTaskLineToVault(task, taskLine, app);
+
+    const newTask = parseTaskLine(taskLine, task.link);
+    if (newTask) {
+      onTaskCreated?.(newTask);
+    }
   };
 
   const handleEdit = async (e: React.MouseEvent) => {

--- a/src/components/task-node.tsx
+++ b/src/components/task-node.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext, useCallback } from "react";
+import React, { useState, useContext, useCallback, useEffect } from "react";
 import { Handle, Position, NodeProps } from "reactflow";
 import { setTooltip } from "obsidian";
 import { Plus } from "lucide-react";
@@ -65,6 +65,7 @@ interface TaskNodeData {
   groupByProject?: boolean;
   // eslint-disable-next-line no-unused-vars -- callback parameter convention
   onDeleteTask?: (taskId: string) => void;
+  onTaskEdited?: (_taskId: string, _updatedTask: BaseTask) => void;
 }
 
 export default function TaskNode({ data, selected }: NodeProps<TaskNodeData>) {
@@ -77,6 +78,7 @@ export default function TaskNode({ data, selected }: NodeProps<TaskNodeData>) {
     tagColorPalette = "rainbow",
     groupByProject = false,
     onDeleteTask,
+    onTaskEdited,
   } = data;
 
   const { allTags, updateTaskTags } = useContext(TagsContext);
@@ -88,6 +90,12 @@ export default function TaskNode({ data, selected }: NodeProps<TaskNodeData>) {
   const [tagError, setTagError] = useState(false);
   const app = useApp();
   const summaryRef = useSummaryRenderer(task.summary, app);
+
+  useEffect(() => {
+    setStatus(task.status);
+    setStarred(task.starred);
+    setTags(task.tags || []);
+  }, [task.status, task.starred, task.tags]);
 
   const isVertical = layoutDirection === "Vertical";
   const targetPosition = isVertical ? Position.Top : Position.Left;
@@ -212,6 +220,7 @@ export default function TaskNode({ data, selected }: NodeProps<TaskNodeData>) {
             task={task}
             app={app}
             onTaskDeleted={() => onDeleteTask?.(task.id)}
+            onTaskEdited={onTaskEdited}
           />
         </div>
 

--- a/src/components/task-node.tsx
+++ b/src/components/task-node.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useContext, useCallback, useEffect } from "react";
+import React, {
+  useState,
+  useContext,
+  useCallback,
+  useEffect,
+  useMemo,
+} from "react";
 import { Handle, Position, NodeProps } from "reactflow";
 import { setTooltip } from "obsidian";
 import { Plus } from "lucide-react";
@@ -20,9 +26,12 @@ import {
   addTagToTaskInVault,
   addStarToTaskInVault,
   editTaskWithTasksModal,
+  getTaskDateProperties,
   removeStarFromTaskInVault,
+  type TaskDateType,
 } from "../lib/utils";
 import { TagsContext } from "../contexts/context";
+import { t } from "../i18n";
 
 export const NODEWIDTH = 250;
 
@@ -36,6 +45,15 @@ const PROJECT_DOT_COLORS = [
   "var(--color-pink)",
   "var(--color-yellow)",
 ];
+
+const TASK_DATE_EMOJIS: Record<TaskDateType, string> = {
+  due: "📅",
+  scheduled: "⏳",
+  start: "🛫",
+  created: "➕",
+  done: "✅",
+  canceled: "❌",
+};
 export const NODEHEIGHT = 120;
 
 interface ProjectDotProps {
@@ -94,6 +112,10 @@ export default function TaskNode({ data, selected }: NodeProps<TaskNodeData>) {
   const [tagError, setTagError] = useState(false);
   const app = useApp();
   const summaryRef = useSummaryRenderer(task.summary, app);
+  const taskDates = useMemo(
+    () => getTaskDateProperties(task.text),
+    [task.text]
+  );
 
   useEffect(() => {
     setStatus(task.status);
@@ -215,7 +237,28 @@ export default function TaskNode({ data, selected }: NodeProps<TaskNodeData>) {
   };
 
   return (
-    <div onDoubleClick={(event) => void handleDoubleClick(event)}>
+    <div
+      className="tasks-map-task-node-root"
+      onDoubleClick={(event) => void handleDoubleClick(event)}
+    >
+      {selected && taskDates.length > 0 && (
+        <div
+          className="tasks-map-task-date-bar"
+          aria-label={t("task_dates.title")}
+        >
+          {taskDates.map(({ type, date }) => (
+            <span className="tasks-map-task-date-item" key={type}>
+              <span className="tasks-map-task-date-emoji" aria-hidden="true">
+                {TASK_DATE_EMOJIS[type]}
+              </span>
+              <span className="tasks-map-task-date-label">
+                {t(`task_dates.${type}`)}
+              </span>
+              <span className="tasks-map-task-date-value">{date}</span>
+            </span>
+          ))}
+        </div>
+      )}
       <Handle type="target" position={targetPosition} />
       <Handle type="source" position={sourcePosition} />
       <TaskBackground

--- a/src/components/task-node.tsx
+++ b/src/components/task-node.tsx
@@ -19,6 +19,7 @@ import {
   removeTagFromTaskInVault,
   addTagToTaskInVault,
   addStarToTaskInVault,
+  editTaskWithTasksModal,
   removeStarFromTaskInVault,
 } from "../lib/utils";
 import { TagsContext } from "../contexts/context";
@@ -195,8 +196,26 @@ export default function TaskNode({ data, selected }: NodeProps<TaskNodeData>) {
     }
   };
 
+  const handleDoubleClick = async (event: React.MouseEvent<HTMLDivElement>) => {
+    const target = event.target as Element;
+    const interactiveTarget = target.closest?.(
+      "button, input, textarea, select, a, [role='button'], .nodrag, .react-flow__handle, .tasks-map-add-tag-button, .tasks-map-tag-remove-icon"
+    );
+    if (interactiveTarget && event.currentTarget.contains(interactiveTarget)) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const updatedTask = await editTaskWithTasksModal(task, app);
+    if (updatedTask) {
+      onTaskEdited?.(task.id, updatedTask);
+    }
+  };
+
   return (
-    <div>
+    <div onDoubleClick={(event) => void handleDoubleClick(event)}>
       <Handle type="target" position={targetPosition} />
       <Handle type="source" position={sourcePosition} />
       <TaskBackground

--- a/src/components/task-node.tsx
+++ b/src/components/task-node.tsx
@@ -65,6 +65,8 @@ interface TaskNodeData {
   groupByProject?: boolean;
   // eslint-disable-next-line no-unused-vars -- callback parameter convention
   onDeleteTask?: (taskId: string) => void;
+  // eslint-disable-next-line no-unused-vars -- callback parameter convention
+  onTaskCreated?: (_newTask: BaseTask) => void;
   onTaskEdited?: (_taskId: string, _updatedTask: BaseTask) => void;
 }
 
@@ -78,6 +80,7 @@ export default function TaskNode({ data, selected }: NodeProps<TaskNodeData>) {
     tagColorPalette = "rainbow",
     groupByProject = false,
     onDeleteTask,
+    onTaskCreated,
     onTaskEdited,
   } = data;
 
@@ -220,6 +223,7 @@ export default function TaskNode({ data, selected }: NodeProps<TaskNodeData>) {
             task={task}
             app={app}
             onTaskDeleted={() => onDeleteTask?.(task.id)}
+            onTaskCreated={onTaskCreated}
             onTaskEdited={onTaskEdited}
           />
         </div>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -122,6 +122,15 @@
     "delete_edge": "Delete edge",
     "insert_task": "Insert task"
   },
+  "task_dates": {
+    "title": "Task dates",
+    "due": "Due",
+    "scheduled": "Scheduled",
+    "start": "Start",
+    "created": "Created",
+    "done": "Done",
+    "canceled": "Canceled"
+  },
   "errors": {
     "cannot_create_edges_different_types": "Cannot create edges between different task types (dataview and note-based tasks). Both tasks must be of the same type.",
     "cannot_insert_task_between_non_dataview": "Insert task between edges is only supported for Dataview tasks."

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -118,8 +118,13 @@
     "no_tasks_hint": "No tasks found in your vault.",
     "all_unlinked_hint": "Drag tasks from the panel on the left onto the graph to place them here."
   },
+  "edge_actions": {
+    "delete_edge": "Delete edge",
+    "insert_task": "Insert task"
+  },
   "errors": {
-    "cannot_create_edges_different_types": "Cannot create edges between different task types (dataview and note-based tasks). Both tasks must be of the same type."
+    "cannot_create_edges_different_types": "Cannot create edges between different task types (dataview and note-based tasks). Both tasks must be of the same type.",
+    "cannot_insert_task_between_non_dataview": "Insert task between edges is only supported for Dataview tasks."
   },
   "notices": {
     "project_assigned": "Added to project: {{projectName}}",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -122,6 +122,15 @@
     "delete_edge": "Verbinding verwijderen",
     "insert_task": "Taak invoegen"
   },
+  "task_dates": {
+    "title": "Taakdatums",
+    "due": "Deadline",
+    "scheduled": "Gepland",
+    "start": "Start",
+    "created": "Aangemaakt",
+    "done": "Voltooid",
+    "canceled": "Geannuleerd"
+  },
   "errors": {
     "cannot_create_edges_different_types": "Kan geen verbindingen maken tussen verschillende taaktypes (dataview en notitie-gebaseerde taken). Beide taken moeten van hetzelfde type zijn.",
     "cannot_insert_task_between_non_dataview": "Een taak invoegen tussen verbindingen wordt alleen ondersteund voor Dataview-taken."

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -118,8 +118,13 @@
     "no_tasks_hint": "Geen taken gevonden in je vault.",
     "all_unlinked_hint": "Sleep taken vanuit het paneel aan de linkerkant naar de grafiek om ze hier te plaatsen."
   },
+  "edge_actions": {
+    "delete_edge": "Verbinding verwijderen",
+    "insert_task": "Taak invoegen"
+  },
   "errors": {
-    "cannot_create_edges_different_types": "Kan geen verbindingen maken tussen verschillende taaktypes (dataview en notitie-gebaseerde taken). Beide taken moeten van hetzelfde type zijn."
+    "cannot_create_edges_different_types": "Kan geen verbindingen maken tussen verschillende taaktypes (dataview en notitie-gebaseerde taken). Beide taken moeten van hetzelfde type zijn.",
+    "cannot_insert_task_between_non_dataview": "Een taak invoegen tussen verbindingen wordt alleen ondersteund voor Dataview-taken."
   },
   "notices": {
     "project_assigned": "Toegevoegd aan project: {{projectName}}",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -122,6 +122,15 @@
     "delete_edge": "删除连线",
     "insert_task": "插入任务"
   },
+  "task_dates": {
+    "title": "任务日期",
+    "due": "截止",
+    "scheduled": "计划",
+    "start": "开始",
+    "created": "创建",
+    "done": "完成",
+    "canceled": "取消"
+  },
   "errors": {
     "cannot_create_edges_different_types": "无法在不同任务类型（dataview 和基于笔记的任务）之间创建连接。两个任务必须是相同类型。",
     "cannot_insert_task_between_non_dataview": "仅 Dataview 任务支持在连线之间插入任务。"

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -118,8 +118,13 @@
     "no_tasks_hint": "在你的 vault 中未找到任何任务。",
     "all_unlinked_hint": "将左侧面板中的任务拖到图上以放置它们。"
   },
+  "edge_actions": {
+    "delete_edge": "删除连线",
+    "insert_task": "插入任务"
+  },
   "errors": {
-    "cannot_create_edges_different_types": "无法在不同任务类型（dataview 和基于笔记的任务）之间创建连接。两个任务必须是相同类型。"
+    "cannot_create_edges_different_types": "无法在不同任务类型（dataview 和基于笔记的任务）之间创建连接。两个任务必须是相同类型。",
+    "cannot_insert_task_between_non_dataview": "仅 Dataview 任务支持在连线之间插入任务。"
   },
   "notices": {
     "project_assigned": "已添加到项目：{{projectName}}",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -243,6 +243,56 @@ export function parseTaskLine(
   });
 }
 
+export function stripTaskLineTags(taskLine: string): {
+  taskLine: string;
+  tags: string[];
+} {
+  const tagPattern = /(?:^|\s)#(\S+)/g;
+  const seenTags = new Set<string>();
+  const tags = Array.from(taskLine.matchAll(tagPattern))
+    .map((match) => match[1])
+    .filter((tag) => {
+      const normalizedTag = tag.toLowerCase();
+      if (seenTags.has(normalizedTag)) return false;
+      seenTags.add(normalizedTag);
+      return true;
+    });
+  const leadingWhitespace = taskLine.match(/^\s*/)?.[0] ?? "";
+  const content = taskLine
+    .slice(leadingWhitespace.length)
+    .replace(tagPattern, (match) => (match.startsWith("#") ? "" : " "))
+    .replace(/[ \t]{2,}/g, " ")
+    .trimEnd();
+
+  return {
+    taskLine: leadingWhitespace + content,
+    tags,
+  };
+}
+
+export function restoreTaskLineTags(
+  taskLine: string,
+  originalTags: string[]
+): string {
+  const existingTags = new Set(
+    Array.from(taskLine.matchAll(/(?:^|\s)#(\S+)/g)).map((match) =>
+      match[1].toLowerCase()
+    )
+  );
+  const tagsToRestore = originalTags.filter((tag) => {
+    const normalizedTag = tag.toLowerCase();
+    if (existingTags.has(normalizedTag)) return false;
+    existingTags.add(normalizedTag);
+    return true;
+  });
+
+  if (tagsToRestore.length === 0) return taskLine;
+
+  return `${taskLine.trimEnd()} ${tagsToRestore
+    .map((tag) => `#${tag}`)
+    .join(" ")}`;
+}
+
 export async function editTaskWithTasksModal(
   task: BaseTask,
   app: App
@@ -268,8 +318,13 @@ export async function editTaskWithTasksModal(
       return null;
     }
 
-    const newTaskLine = await tasksApi.editTaskLineModal(lines[taskLineIdx]);
-    if (!newTaskLine?.trim()) return null;
+    const preparedTask = stripTaskLineTags(lines[taskLineIdx]);
+    const editedTaskLine = await tasksApi.editTaskLineModal(
+      preparedTask.taskLine
+    );
+    if (!editedTaskLine?.trim()) return null;
+
+    const newTaskLine = restoreTaskLineTags(editedTaskLine, preparedTask.tags);
 
     lines[taskLineIdx] = newTaskLine;
     await app.vault.modify(file, lines.join("\n"));

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -243,6 +243,70 @@ export function parseTaskLine(
   });
 }
 
+export type TaskDateType =
+  | "due"
+  | "scheduled"
+  | "start"
+  | "created"
+  | "done"
+  | "canceled";
+
+export interface TaskDateProperty {
+  type: TaskDateType;
+  date: string;
+}
+
+const TASK_DATE_DEFINITIONS: Array<{
+  type: TaskDateType;
+  emoji: string;
+  fields: string[];
+}> = [
+  { type: "due", emoji: "📅", fields: ["due"] },
+  { type: "scheduled", emoji: "⏳", fields: ["scheduled"] },
+  { type: "start", emoji: "🛫", fields: ["start"] },
+  { type: "created", emoji: "➕", fields: ["created"] },
+  { type: "done", emoji: "✅", fields: ["completion", "done"] },
+  {
+    type: "canceled",
+    emoji: "❌",
+    fields: ["canceled", "cancelled"],
+  },
+];
+
+export function getTaskDateProperties(taskText: string): TaskDateProperty[] {
+  const datePattern = "(\\d{4}-\\d{2}-\\d{2})";
+
+  return TASK_DATE_DEFINITIONS.flatMap(({ type, emoji, fields }) => {
+    const emojiMatch = taskText.match(
+      new RegExp(`${emoji}\\s*${datePattern}`, "u")
+    );
+    if (emojiMatch) {
+      return [{ type, date: emojiMatch[1] }];
+    }
+
+    for (const field of fields) {
+      const dataviewMatch = taskText.match(
+        new RegExp(
+          `(?:\\[\\[?|\\()${field}::\\s*${datePattern}(?:\\]\\]?|\\))`,
+          "i"
+        )
+      );
+      if (dataviewMatch) {
+        return [{ type, date: dataviewMatch[1] }];
+      }
+
+      const textMatch = taskText.match(
+        new RegExp(`(?:^|\\s)${field}:\\s*${datePattern}(?=\\s|$)`, "i")
+      );
+      if (textMatch) {
+        return [{ type, date: textMatch[1] }];
+      }
+    }
+
+    return [];
+  });
+}
+
 export function stripTaskLineTags(taskLine: string): {
   taskLine: string;
   tags: string[];

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -243,6 +243,51 @@ export function parseTaskLine(
   });
 }
 
+export async function editTaskWithTasksModal(
+  task: BaseTask,
+  app: App
+): Promise<BaseTask | null> {
+  if (!task.link) return null;
+
+  const file = app.vault.getFileByPath(task.link);
+  if (!file) return null;
+
+  const tasksApi = getTasksApi(app);
+  if (!tasksApi) {
+    console.error("Tasks plugin not found or API not available");
+    return null;
+  }
+
+  try {
+    const fileContent = await app.vault.read(file);
+    const lines = fileContent.split(/\r?\n/);
+    const taskLineIdx = findTaskLineByIdOrText(lines, task.id, task.text);
+
+    if (taskLineIdx === -1) {
+      console.warn("Task line not found");
+      return null;
+    }
+
+    const newTaskLine = await tasksApi.editTaskLineModal(lines[taskLineIdx]);
+    if (!newTaskLine?.trim()) return null;
+
+    lines[taskLineIdx] = newTaskLine;
+    await app.vault.modify(file, lines.join("\n"));
+
+    const updatedTask = parseTaskLine(newTaskLine, task.link);
+    if (!updatedTask) return null;
+
+    if (!newTaskLine.includes(updatedTask.id)) {
+      updatedTask.id = task.id;
+    }
+    updatedTask.projects = task.projects;
+    return updatedTask;
+  } catch (error) {
+    console.error("Error processing task:", error);
+    return null;
+  }
+}
+
 export async function deleteTaskFromVault(
   task: BaseTask,
   app: App

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -149,6 +149,47 @@ export function findTaskLineByIdOrText(
   return taskLineIdx;
 }
 
+function parseMetadataIds(value: string): string[] {
+  return value
+    .split(",")
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0);
+}
+
+function lineContainsDependencyHash(line: string, hash: string): boolean {
+  const dataviewMatches = [
+    ...line.matchAll(/\[dependsOn::\s*([^\]]+)\]/gi),
+    ...line.matchAll(/\(dependsOn::\s*([^)]+)\)/gi),
+  ];
+
+  if (
+    dataviewMatches.some((match) => parseMetadataIds(match[1]).includes(hash))
+  ) {
+    return true;
+  }
+
+  return line.includes(hash);
+}
+
+function findTaskLineForSignRemoval(
+  lines: string[],
+  task: BaseTask,
+  type: "stop" | "id",
+  hash: string
+): number {
+  const taskLineIdx = findTaskLineByIdOrText(lines, task.id, task.text);
+  if (taskLineIdx !== -1) return taskLineIdx;
+
+  if (type === "id") {
+    return lines.findIndex(
+      (line) =>
+        line.includes(hash) && line.toLowerCase().includes("id::")
+    );
+  }
+
+  return lines.findIndex((line) => lineContainsDependencyHash(line, hash));
+}
+
 export async function updateTaskStatusInVault(
   task: BaseTask,
   newStatus: TaskStatus,
@@ -1014,7 +1055,7 @@ export async function addSignToTaskInFile(
 
   await vault.process(file, (fileContent) => {
     const lines = fileContent.split(/\r?\n/);
-    const taskLineIdx = lines.findIndex((line) => line.includes(task.text));
+    const taskLineIdx = findTaskLineByIdOrText(lines, task.id, task.text);
     if (taskLineIdx === -1) return fileContent;
 
     if (type === "id") {
@@ -1150,7 +1191,7 @@ export async function removeSignFromTaskInFile(
 
   await vault.process(file, (fileContent) => {
     const lines = fileContent.split(/\r?\n/);
-    const taskLineIdx = lines.findIndex((line) => line.includes(task.text));
+    const taskLineIdx = findTaskLineForSignRemoval(lines, task, type, hash);
     if (taskLineIdx === -1) return fileContent;
 
     if (type === "id") {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1557,7 +1557,8 @@ export function createNodesFromTasks(
   onDeleteTask?: (taskId: string) => void,
   groupByProject: boolean = true,
   tagColorPalette: TagColorPalette = "rainbow",
-  onTaskEdited?: (_taskId: string, _updatedTask: BaseTask) => void
+  onTaskEdited?: (_taskId: string, _updatedTask: BaseTask) => void,
+  onTaskCreated?: (_newTask: BaseTask) => void
 ): TaskNode[] {
   const isVertical = layoutDirection === "Vertical";
   const sourcePosition = isVertical ? Position.Bottom : Position.Right;
@@ -1576,6 +1577,7 @@ export function createNodesFromTasks(
       tagColorPalette,
       onDeleteTask,
       onTaskEdited,
+      onTaskCreated,
     },
     type: "task" as const,
     sourcePosition,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1515,7 +1515,8 @@ export function createNodesFromTasks(
   // eslint-disable-next-line no-unused-vars -- callback parameter convention
   onDeleteTask?: (taskId: string) => void,
   groupByProject: boolean = true,
-  tagColorPalette: TagColorPalette = "rainbow"
+  tagColorPalette: TagColorPalette = "rainbow",
+  onTaskEdited?: (_taskId: string, _updatedTask: BaseTask) => void
 ): TaskNode[] {
   const isVertical = layoutDirection === "Vertical";
   const sourcePosition = isVertical ? Position.Bottom : Position.Right;
@@ -1533,6 +1534,7 @@ export function createNodesFromTasks(
       groupByProject,
       tagColorPalette,
       onDeleteTask,
+      onTaskEdited,
     },
     type: "task" as const,
     sourcePosition,

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -24,6 +24,8 @@ export interface TaskNodeData {
   tagColorPalette?: TagColorPalette;
   // eslint-disable-next-line no-unused-vars -- callback parameter convention
   onDeleteTask?: (taskId: string) => void;
+  // eslint-disable-next-line no-unused-vars -- callback parameter convention
+  onTaskCreated?: (_newTask: BaseTask) => void;
   onTaskEdited?: (_taskId: string, _updatedTask: BaseTask) => void;
 }
 

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -24,6 +24,7 @@ export interface TaskNodeData {
   tagColorPalette?: TagColorPalette;
   // eslint-disable-next-line no-unused-vars -- callback parameter convention
   onDeleteTask?: (taskId: string) => void;
+  onTaskEdited?: (_taskId: string, _updatedTask: BaseTask) => void;
 }
 
 export interface TaskEdgeData {

--- a/src/views/TaskMapGraphView.tsx
+++ b/src/views/TaskMapGraphView.tsx
@@ -61,6 +61,10 @@ interface TaskMapGraphViewProps {
   reloadRef?: React.MutableRefObject<(() => void) | null>;
 }
 
+interface ReloadTasksOptions {
+  preserveViewport?: boolean;
+}
+
 export default function TaskMapGraphView({
   settings,
   filterState,
@@ -159,30 +163,40 @@ export default function TaskMapGraphView({
     }
   }, [hideTags]);
 
-  const reloadTasks = useCallback(() => {
-    setIsLoading(true);
-    // Reset dropped state on reload so unlinked tasks return to sidebar
-    setDroppedTaskIds(new Set());
-    droppedNodePositions.current = new Map();
-    // Use setTimeout to allow the loading UI to render before heavy computation
-    window.setTimeout(() => {
-      const newTasks = getAllTasks(app);
-      setTasks(newTasks);
-      const newRegistry = new Map<string, string[]>();
-      newTasks.forEach((task) => {
-        newRegistry.set(task.id, task.tags);
-      });
-      setTaskTagsRegistry(newRegistry);
-      setIsLoading(false);
-      new Notice("Tasks reloaded");
-    }, 0);
-  }, [app]);
+  const reloadTasks = useCallback(
+    ({ preserveViewport = false }: ReloadTasksOptions = {}) => {
+      setIsLoading(true);
+      // Use setTimeout to allow the loading UI to render before heavy computation
+      window.setTimeout(() => {
+        if (preserveViewport) {
+          skipFitViewRef.current = true;
+        }
+        // Reset dropped state on reload so unlinked tasks return to sidebar
+        setDroppedTaskIds(new Set());
+        droppedNodePositions.current = new Map();
+        const newTasks = getAllTasks(app);
+        setTasks(newTasks);
+        const newRegistry = new Map<string, string[]>();
+        newTasks.forEach((task) => {
+          newRegistry.set(task.id, task.tags);
+        });
+        setTaskTagsRegistry(newRegistry);
+        setIsLoading(false);
+        new Notice("Tasks reloaded");
+      }, 0);
+    },
+    [app]
+  );
+
+  const handleReloadTasks = useCallback(() => {
+    reloadTasks({ preserveViewport: true });
+  }, [reloadTasks]);
 
   useEffect(() => {
     if (reloadRef) {
-      reloadRef.current = reloadTasks;
+      reloadRef.current = handleReloadTasks;
     }
-  }, [reloadRef, reloadTasks]);
+  }, [reloadRef, handleReloadTasks]);
 
   const updateTaskTags = useCallback((taskId: string, newTags: string[]) => {
     setTaskTagsRegistry((prevRegistry) => {
@@ -992,7 +1006,7 @@ export default function TaskMapGraphView({
                 showTags={settings.showTags}
                 hideTags={hideTags}
                 setHideTags={toggleHideTags}
-                reloadTasks={reloadTasks}
+                reloadTasks={handleReloadTasks}
                 showUnlinkedPanel={embed.showUnlinkedPanel}
                 hideUnlinkedTasks={hideUnlinkedTasks}
                 setHideUnlinkedTasks={setHideUnlinkedTasks}

--- a/src/views/TaskMapGraphView.tsx
+++ b/src/views/TaskMapGraphView.tsx
@@ -358,6 +358,33 @@ export default function TaskMapGraphView({
     setSelectedEdge(null);
   }, [setSelectedEdge]);
 
+  const createUpdatedTask = useCallback(
+    (task: BaseTask, incomingLinks: string[]) =>
+      Object.assign(Object.create(Object.getPrototypeOf(task)), task, {
+        incomingLinks,
+      }) as BaseTask,
+    []
+  );
+
+  const updateTaskIncomingLinks = useCallback(
+    (
+      taskId: string,
+      updateIncomingLinks: (_incomingLinks: string[]) => string[]
+    ) => {
+      setTasks((prevTasks) =>
+        prevTasks.map((task) =>
+          task.id === taskId
+            ? createUpdatedTask(
+                task,
+                updateIncomingLinks(task.incomingLinks)
+              )
+            : task
+        )
+      );
+    },
+    [createUpdatedTask]
+  );
+
   const onDeleteSelectedEdge = useCallback(async () => {
     if (!selectedEdge) return;
 
@@ -370,10 +397,21 @@ export default function TaskMapGraphView({
 
     if (vault) {
       await removeLinkSignsBetweenTasks(vault, targetTask, sourceTask.id);
+      skipFitViewRef.current = true;
+      updateTaskIncomingLinks(targetTask.id, (incomingLinks) =>
+        incomingLinks.filter((id) => id !== sourceTask.id)
+      );
       setEdges((eds) => eds.filter((e) => e.id !== selectedEdge));
       setSelectedEdge(null);
     }
-  }, [selectedEdge, edges, tasks, vault, setEdges]);
+  }, [
+    selectedEdge,
+    edges,
+    tasks,
+    vault,
+    setEdges,
+    updateTaskIncomingLinks,
+  ]);
 
   const onConnect = useCallback(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ReactFlow Connection type is not exported
@@ -387,6 +425,10 @@ export default function TaskMapGraphView({
 
       if (!vault || !sourceTask || !targetTask) return;
 
+      if (targetTask.incomingLinks.includes(sourceTask.id)) {
+        return;
+      }
+
       if (sourceTask.type !== targetTask.type) {
         new Notice(t("errors.cannot_create_edges_different_types"), 5000);
         return;
@@ -399,6 +441,12 @@ export default function TaskMapGraphView({
         settings.linkingStyle
       );
       if (hash) {
+        skipFitViewRef.current = true;
+        updateTaskIncomingLinks(targetTask.id, (incomingLinks) =>
+          incomingLinks.includes(sourceTask.id)
+            ? incomingLinks
+            : [...incomingLinks, sourceTask.id]
+        );
         setEdges((eds) =>
           addEdge(
             {
@@ -419,18 +467,11 @@ export default function TaskMapGraphView({
       vault,
       tasks,
       setEdges,
+      updateTaskIncomingLinks,
       settings.layoutDirection,
       settings.debugVisualization,
       settings.linkingStyle,
     ]
-  );
-
-  const createUpdatedTask = useCallback(
-    (task: BaseTask, incomingLinks: string[]) =>
-      Object.assign(Object.create(Object.getPrototypeOf(task)), task, {
-        incomingLinks,
-      }) as BaseTask,
-    []
   );
 
   const createConnectedTask = useCallback(

--- a/src/views/TaskMapGraphView.tsx
+++ b/src/views/TaskMapGraphView.tsx
@@ -216,6 +216,43 @@ export default function TaskMapGraphView({
     });
   }, []);
 
+  const handleTaskEdited = useCallback(
+    (taskId: string, updatedTask: BaseTask) => {
+      skipFitViewRef.current = true;
+      setTasks((prevTasks) =>
+        prevTasks.map((task) => (task.id === taskId ? updatedTask : task))
+      );
+      setTaskTagsRegistry((prevRegistry) => {
+        const newRegistry = new Map(prevRegistry);
+        if (taskId !== updatedTask.id) {
+          newRegistry.delete(taskId);
+        }
+        newRegistry.set(updatedTask.id, updatedTask.tags);
+        return newRegistry;
+      });
+
+      if (taskId === updatedTask.id) return;
+
+      setDroppedTaskIds((prevDroppedTaskIds) => {
+        if (!prevDroppedTaskIds.has(taskId)) {
+          return prevDroppedTaskIds;
+        }
+
+        const nextDroppedTaskIds = new Set(prevDroppedTaskIds);
+        nextDroppedTaskIds.delete(taskId);
+        nextDroppedTaskIds.add(updatedTask.id);
+        return nextDroppedTaskIds;
+      });
+
+      const droppedPosition = droppedNodePositions.current.get(taskId);
+      if (droppedPosition) {
+        droppedNodePositions.current.delete(taskId);
+        droppedNodePositions.current.set(updatedTask.id, droppedPosition);
+      }
+    },
+    []
+  );
+
   useEffect(() => {
     // Get the Dataview plugin to check index status
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Obsidian App type does not expose plugins property
@@ -280,7 +317,8 @@ export default function TaskMapGraphView({
       settings.debugVisualization,
       handleDeleteTask,
       groupByProject,
-      settings.tagColorPalette
+      settings.tagColorPalette,
+      handleTaskEdited
     );
     let newEdges = createEdgesFromTasks(
       graphTasks,
@@ -339,6 +377,7 @@ export default function TaskMapGraphView({
     setNodes,
     setEdges,
     handleDeleteTask,
+    handleTaskEdited,
     droppedTaskIds,
     groupByProject,
   ]);

--- a/src/views/TaskMapGraphView.tsx
+++ b/src/views/TaskMapGraphView.tsx
@@ -79,6 +79,9 @@ export default function TaskMapGraphView({
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
   const [tasks, setTasks] = React.useState<BaseTask[]>([]);
+  const [newlyCreatedTaskIds, setNewlyCreatedTaskIds] = React.useState<
+    Set<string>
+  >(new Set());
   const [selectedEdge, setSelectedEdge] = React.useState<string | null>(null);
   const [isLoading, setIsLoading] = React.useState(true);
   const reactFlowInstance = useReactFlow();
@@ -173,6 +176,7 @@ export default function TaskMapGraphView({
         }
         // Reset dropped state on reload so unlinked tasks return to sidebar
         setDroppedTaskIds(new Set());
+        setNewlyCreatedTaskIds(new Set());
         droppedNodePositions.current = new Map();
         const newTasks = getAllTasks(app);
         setTasks(newTasks);
@@ -209,11 +213,30 @@ export default function TaskMapGraphView({
   const handleDeleteTask = useCallback((taskId: string) => {
     skipFitViewRef.current = true;
     setTasks((prevTasks) => prevTasks.filter((t) => t.id !== taskId));
+    setNewlyCreatedTaskIds((prevTaskIds) => {
+      if (!prevTaskIds.has(taskId)) return prevTaskIds;
+
+      const nextTaskIds = new Set(prevTaskIds);
+      nextTaskIds.delete(taskId);
+      return nextTaskIds;
+    });
     setTaskTagsRegistry((prevRegistry) => {
       const newRegistry = new Map(prevRegistry);
       newRegistry.delete(taskId);
       return newRegistry;
     });
+  }, []);
+
+  const handleTaskCreated = useCallback((newTask: BaseTask) => {
+    skipFitViewRef.current = true;
+    setNewlyCreatedTaskIds((prevTaskIds) =>
+      new Set(prevTaskIds).add(newTask.id)
+    );
+    setTasks((prevTasks) =>
+      prevTasks.some((task) => task.id === newTask.id)
+        ? prevTasks
+        : [...prevTasks, newTask]
+    );
   }, []);
 
   const handleTaskEdited = useCallback(
@@ -232,6 +255,15 @@ export default function TaskMapGraphView({
       });
 
       if (taskId === updatedTask.id) return;
+
+      setNewlyCreatedTaskIds((prevTaskIds) => {
+        if (!prevTaskIds.has(taskId)) return prevTaskIds;
+
+        const nextTaskIds = new Set(prevTaskIds);
+        nextTaskIds.delete(taskId);
+        nextTaskIds.add(updatedTask.id);
+        return nextTaskIds;
+      });
 
       setDroppedTaskIds((prevDroppedTaskIds) => {
         if (!prevDroppedTaskIds.has(taskId)) {
@@ -295,8 +327,9 @@ export default function TaskMapGraphView({
     const filteredIds = new Set(
       getFilteredNodeIds(undroppedUnlinked, filterState)
     );
+    newlyCreatedTaskIds.forEach((taskId) => filteredIds.add(taskId));
     return undroppedUnlinked.filter((t) => filteredIds.has(t.id));
-  }, [allUnlinkedTasks, droppedTaskIds, filterState]);
+  }, [allUnlinkedTasks, droppedTaskIds, filterState, newlyCreatedTaskIds]);
 
   // Tasks that are linked OR have been dropped onto the canvas this session
   // OR all tasks when hideUnlinkedTasks is disabled (unlinked appear as isolated nodes)
@@ -318,7 +351,8 @@ export default function TaskMapGraphView({
       handleDeleteTask,
       groupByProject,
       settings.tagColorPalette,
-      handleTaskEdited
+      handleTaskEdited,
+      handleTaskCreated
     );
     let newEdges = createEdgesFromTasks(
       graphTasks,
@@ -329,6 +363,11 @@ export default function TaskMapGraphView({
     );
 
     const filteredNodeIds = getFilteredNodeIds(graphTasks, filterState);
+    newlyCreatedTaskIds.forEach((taskId) => {
+      if (!filteredNodeIds.includes(taskId)) {
+        filteredNodeIds.push(taskId);
+      }
+    });
     const filteredTasks = graphTasks.filter((t) =>
       filteredNodeIds.includes(t.id)
     );
@@ -378,6 +417,8 @@ export default function TaskMapGraphView({
     setEdges,
     handleDeleteTask,
     handleTaskEdited,
+    handleTaskCreated,
+    newlyCreatedTaskIds,
     droppedTaskIds,
     groupByProject,
   ]);
@@ -531,6 +572,9 @@ export default function TaskMapGraphView({
       );
 
       skipFitViewRef.current = true;
+      setNewlyCreatedTaskIds((prevTaskIds) =>
+        new Set(prevTaskIds).add(newTask.id)
+      );
       setTasks((prevTasks) => {
         const taskToAdd = createUpdatedTask(newTask, [
           ...new Set([...newTask.incomingLinks, sourceTask.id]),
@@ -700,6 +744,9 @@ export default function TaskMapGraphView({
         }
 
         skipFitViewRef.current = true;
+        setNewlyCreatedTaskIds((prevTaskIds) =>
+          new Set(prevTaskIds).add(newTask.id)
+        );
         setTasks((prevTasks) => {
           const nextTasks =
             relation === "after"
@@ -1041,14 +1088,16 @@ export default function TaskMapGraphView({
       traversalMode: "match",
     });
     const idSet = new Set(filteredIds);
+    newlyCreatedTaskIds.forEach((taskId) => idSet.add(taskId));
     return graphTasks.filter((t) => idSet.has(t.id));
-  }, [graphTasks, filterState]);
+  }, [graphTasks, filterState, newlyCreatedTaskIds]);
 
   const filteredTasks = useMemo(() => {
     const filteredIds = getFilteredNodeIds(graphTasks, filterState);
     const idSet = new Set(filteredIds);
+    newlyCreatedTaskIds.forEach((taskId) => idSet.add(taskId));
     return graphTasks.filter((t) => idSet.has(t.id));
-  }, [graphTasks, filterState]);
+  }, [graphTasks, filterState, newlyCreatedTaskIds]);
 
   const searchResultCount = useMemo(() => {
     if (!filterState.searchQuery.trim()) return null;

--- a/src/views/TaskMapGraphView.tsx
+++ b/src/views/TaskMapGraphView.tsx
@@ -411,6 +411,19 @@ export default function TaskMapGraphView({
     setSelectedEdge(null);
   }, [setSelectedEdge]);
 
+  const getSelectedEdgeTasks = useCallback(() => {
+    if (!selectedEdge) return null;
+
+    const edge = edges.find((e) => e.id === selectedEdge);
+    if (!edge) return null;
+
+    const sourceTask = tasks.find((t) => t.id === edge.source);
+    const targetTask = tasks.find((t) => t.id === edge.target);
+    if (!sourceTask || !targetTask) return null;
+
+    return { edge, sourceTask, targetTask };
+  }, [selectedEdge, edges, tasks]);
+
   const createUpdatedTask = useCallback(
     (task: BaseTask, incomingLinks: string[]) =>
       Object.assign(Object.create(Object.getPrototypeOf(task)), task, {
@@ -439,14 +452,11 @@ export default function TaskMapGraphView({
   );
 
   const onDeleteSelectedEdge = useCallback(async () => {
-    if (!selectedEdge) return;
+    const selected = getSelectedEdgeTasks();
+    if (!selected) return;
 
-    const edge = edges.find((e) => e.id === selectedEdge);
+    const { edge, sourceTask, targetTask } = selected;
     if (!edge || !edge.data?.hash) return;
-
-    const sourceTask = tasks.find((t) => t.id === edge.source);
-    const targetTask = tasks.find((t) => t.id === edge.target);
-    if (!sourceTask || !targetTask) return;
 
     if (vault) {
       await removeLinkSignsBetweenTasks(vault, targetTask, sourceTask.id);
@@ -459,11 +469,116 @@ export default function TaskMapGraphView({
     }
   }, [
     selectedEdge,
-    edges,
-    tasks,
     vault,
     setEdges,
+    getSelectedEdgeTasks,
     updateTaskIncomingLinks,
+  ]);
+
+  const onInsertTaskBetweenSelectedEdge = useCallback(async () => {
+    const selected = getSelectedEdgeTasks();
+    if (!selected || !vault) return;
+
+    const { sourceTask, targetTask } = selected;
+    if (sourceTask.type !== "dataview" || targetTask.type !== "dataview") {
+      new Notice(t("errors.cannot_insert_task_between_non_dataview"), 5000);
+      return;
+    }
+
+    const tasksApi = getTasksApi(app);
+    if (!tasksApi) {
+      console.error("Tasks plugin not found or API not available");
+      return;
+    }
+
+    const taskLine = await tasksApi.createTaskLineModal();
+    if (!taskLine?.trim()) {
+      return;
+    }
+
+    const newTask = parseTaskLine(taskLine, sourceTask.link);
+    if (!newTask || newTask.type !== sourceTask.type) {
+      return;
+    }
+
+    let newTaskWritten = false;
+    let oldLinkRemoved = false;
+
+    try {
+      await addTaskLineToVault(sourceTask, taskLine, app, "after");
+      newTaskWritten = true;
+
+      await addSignToTaskInFile(
+        vault,
+        newTask,
+        "id",
+        newTask.id,
+        settings.linkingStyle
+      );
+      await removeLinkSignsBetweenTasks(vault, targetTask, sourceTask.id);
+      oldLinkRemoved = true;
+      await addLinkSignsBetweenTasks(
+        vault,
+        sourceTask,
+        newTask,
+        settings.linkingStyle
+      );
+      await addLinkSignsBetweenTasks(
+        vault,
+        newTask,
+        targetTask,
+        settings.linkingStyle
+      );
+
+      skipFitViewRef.current = true;
+      setTasks((prevTasks) => {
+        const taskToAdd = createUpdatedTask(newTask, [
+          ...new Set([...newTask.incomingLinks, sourceTask.id]),
+        ]);
+
+        return [
+          ...prevTasks.map((task) => {
+            if (task.id !== targetTask.id) return task;
+
+            const nextIncomingLinks = task.incomingLinks.filter(
+              (id) => id !== sourceTask.id
+            );
+
+            return createUpdatedTask(task, [
+              ...new Set([...nextIncomingLinks, newTask.id]),
+            ]);
+          }),
+          taskToAdd,
+        ];
+      });
+      setSelectedEdge(null);
+    } catch (error) {
+      console.error("Failed to insert task between edge:", error);
+
+      try {
+        await removeLinkSignsBetweenTasks(vault, targetTask, newTask.id);
+        await removeLinkSignsBetweenTasks(vault, newTask, sourceTask.id);
+        if (oldLinkRemoved) {
+          await addLinkSignsBetweenTasks(
+            vault,
+            sourceTask,
+            targetTask,
+            settings.linkingStyle
+          );
+        }
+        if (newTaskWritten) {
+          await deleteTaskFromVault(newTask, app);
+        }
+      } catch (rollbackError) {
+        console.error("Failed to rollback inserted task:", rollbackError);
+      }
+    }
+  }, [
+    app,
+    createUpdatedTask,
+    getSelectedEdgeTasks,
+    settings.linkingStyle,
+    vault,
   ]);
 
   const onConnect = useCallback(
@@ -1062,7 +1177,10 @@ export default function TaskMapGraphView({
           )}
         </ReactFlow>
         {selectedEdge && (
-          <DeleteEdgeButton onDelete={() => void onDeleteSelectedEdge()} />
+          <DeleteEdgeButton
+            onDelete={() => void onDeleteSelectedEdge()}
+            onInsertTask={() => void onInsertTaskBetweenSelectedEdge()}
+          />
         )}
       </div>
     </TagsContext.Provider>

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -366,6 +366,24 @@ describe("createNodesFromTasks", () => {
     expect(nodes[0].data.showTags).toBe(false);
     expect(nodes[0].data.debugVisualization).toBe(true);
   });
+
+  it("passes through the task edit callback", () => {
+    const task = makeTask();
+    const handleTaskEdited = jest.fn();
+    const nodes = createNodesFromTasks(
+      [task],
+      "Horizontal",
+      true,
+      true,
+      false,
+      undefined,
+      true,
+      "rainbow",
+      handleTaskEdited
+    );
+
+    expect(nodes[0].data.onTaskEdited).toBe(handleTaskEdited);
+  });
 });
 
 describe("createEdgesFromTasks", () => {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -17,6 +17,7 @@ import {
   stripTaskLineTags,
   restoreTaskLineTags,
   editTaskWithTasksModal,
+  getTaskDateProperties,
 } from "../src/lib/utils";
 import { NoteTask } from "../src/types/note-task";
 import { App, Vault } from "./mocks/obsidian";
@@ -155,6 +156,40 @@ describe("task line tags in Tasks editor", () => {
       "- [ ] Updated task #new [id:: abc123] #work #project/docs"
     );
     expect(updatedTask?.tags).toEqual(["new", "work", "project/docs"]);
+  });
+});
+
+describe("getTaskDateProperties", () => {
+  it("extracts all Tasks emoji date properties in display order", () => {
+    const result = getTaskDateProperties(
+      "Task ➕ 2025-01-01 ⏳ 2025-01-10 🛫 2025-01-11 📅 2025-01-15 ✅ 2025-01-14 ❌ 2025-01-16"
+    );
+
+    expect(result).toEqual([
+      { type: "due", date: "2025-01-15" },
+      { type: "scheduled", date: "2025-01-10" },
+      { type: "start", date: "2025-01-11" },
+      { type: "created", date: "2025-01-01" },
+      { type: "done", date: "2025-01-14" },
+      { type: "canceled", date: "2025-01-16" },
+    ]);
+  });
+
+  it("extracts Dataview and text date fields", () => {
+    const result = getTaskDateProperties(
+      "Task [due:: 2025-03-01] [[scheduled::2025-02-20]] start:2025-02-21 completion:2025-03-02"
+    );
+
+    expect(result).toEqual([
+      { type: "due", date: "2025-03-01" },
+      { type: "scheduled", date: "2025-02-20" },
+      { type: "start", date: "2025-02-21" },
+      { type: "done", date: "2025-03-02" },
+    ]);
+  });
+
+  it("returns no properties when the task has no dates", () => {
+    expect(getTaskDateProperties("Task without dates")).toEqual([]);
   });
 });
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -14,9 +14,12 @@ import {
   partitionTasksByProject,
   addSignToTaskInFile,
   removeSignFromTaskInFile,
+  stripTaskLineTags,
+  restoreTaskLineTags,
+  editTaskWithTasksModal,
 } from "../src/lib/utils";
 import { NoteTask } from "../src/types/note-task";
-import { Vault } from "./mocks/obsidian";
+import { App, Vault } from "./mocks/obsidian";
 
 function makeTask(
   overrides: Partial<ConstructorParameters<typeof NoteTask>[0]> = {}
@@ -81,6 +84,79 @@ function getAxisGap(
   }
   return 0;
 }
+
+describe("task line tags in Tasks editor", () => {
+  it("removes existing tags while preserving task indentation and metadata", () => {
+    const result = stripTaskLineTags(
+      "  - [ ] Write docs #work #project/docs [id:: abc123]"
+    );
+
+    expect(result).toEqual({
+      taskLine: "  - [ ] Write docs [id:: abc123]",
+      tags: ["work", "project/docs"],
+    });
+  });
+
+  it("restores original tags and keeps tags added in the Tasks editor", () => {
+    const result = restoreTaskLineTags("- [ ] Update docs #new", [
+      "work",
+      "project/docs",
+    ]);
+
+    expect(result).toBe("- [ ] Update docs #new #work #project/docs");
+  });
+
+  it("does not duplicate tags re-added in the Tasks editor", () => {
+    const result = restoreTaskLineTags("- [ ] Update docs #work", [
+      "Work",
+      "work",
+      "project",
+    ]);
+
+    expect(result).toBe("- [ ] Update docs #work #project");
+  });
+
+  it("hides original tags from the modal and restores them after editing", async () => {
+    const app = new App();
+    const editTaskLineModal = jest
+      .fn<Promise<string>, [string]>()
+      .mockResolvedValue("- [ ] Updated task #new [id:: abc123]");
+    const appWithPlugins = app as App & {
+      plugins: {
+        plugins: {
+          "obsidian-tasks-plugin": {
+            apiV1: { editTaskLineModal: typeof editTaskLineModal };
+          };
+        };
+      };
+    };
+    appWithPlugins.plugins = {
+      plugins: {
+        "obsidian-tasks-plugin": {
+          apiV1: { editTaskLineModal },
+        },
+      },
+    };
+    app.vault.setFileContent(
+      "tasks/test.md",
+      "- [ ] Original task #work #project/docs [id:: abc123]"
+    );
+    const task = makeTask({
+      text: "Original task #work #project/docs [id:: abc123]",
+      tags: ["work", "project/docs"],
+    });
+
+    const updatedTask = await editTaskWithTasksModal(task, appWithPlugins);
+
+    expect(editTaskLineModal).toHaveBeenCalledWith(
+      "- [ ] Original task [id:: abc123]"
+    );
+    expect(app.vault.getFileContent("tasks/test.md")).toBe(
+      "- [ ] Updated task #new [id:: abc123] #work #project/docs"
+    );
+    expect(updatedTask?.tags).toEqual(["new", "work", "project/docs"]);
+  });
+});
 
 describe("addDateToTask", () => {
   it("adds an emoji-format due date to a plain task", () => {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -815,6 +815,25 @@ describe("removeSignFromTaskInFile", () => {
     expect(content).not.toContain("abc123");
   });
 
+  it("removes consecutive hashes when the task text still has stale metadata", async () => {
+    const vault = makeVault(
+      "- [ ] Test task [dependsOn:: abc123, def456, ghi789]"
+    );
+    const task = makeTask({
+      id: "target1",
+      text: "Test task [dependsOn:: abc123, def456, ghi789]",
+      link: "tasks/test.md",
+    });
+
+    await removeSignFromTaskInFile(vault as any, task, "stop", "abc123");
+    await removeSignFromTaskInFile(vault as any, task, "stop", "def456");
+
+    const content = vault.getFileContent("tasks/test.md");
+    expect(content).toContain("[dependsOn:: ghi789]");
+    expect(content).not.toContain("abc123");
+    expect(content).not.toContain("def456");
+  });
+
   it("removes entire dataview dependsOn block when last hash removed", async () => {
     const vault = makeVault("- [ ] Test task [dependsOn:: abc123]");
     const task = makeTask({ text: "Test task", link: "tasks/test.md" });


### PR DESCRIPTION
Summary
This PR introduces several quality-of-life improvements and bug fixes to enhance the overall user experience when working with tasks and edges on the canvas.

Changes Included
1. Preserve canvas zoom level on task reload
Previously, reloading tasks would automatically fit the canvas, which caused unexpected zoom resets.

This behavior was particularly disruptive when updating edge links, as it would frequently shift the visual focus and disorient the user.

With this change, reloading tasks no longer triggers a canvas fit action. The current zoom level and viewport position are now preserved, allowing for a smoother and more focused workflow.

2. Fix operation loss when adding/removing edges multiple times
Fixed an issue where repeated addition and deletion of edges could lead to inconsistent state and lost operations.

The edge management logic has been revised to correctly handle multiple sequential updates, ensuring that all add/remove actions are properly captured and applied.

This resolves unexpected behavior where some edge changes would silently fail or revert after several operations.

Impact
Users will experience fewer interruptions during canvas interactions.

Edge editing is now more reliable and predictable, especially in complex workflows with frequent modifications.