### PR TITLE
fix: robustly locate task lines when adding/removing dependency signs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ styles.css
 
 # obsidian
 data.json
+test/fixture/TaskNotes/Views/
 
 # Exclude macOS Finder (System Explorer) View States
 .DS_Store

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -149,6 +149,46 @@ export function findTaskLineByIdOrText(
   return taskLineIdx;
 }
 
+function parseMetadataIds(value: string): string[] {
+  return value
+    .split(",")
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0);
+}
+
+function lineContainsDependencyHash(line: string, hash: string): boolean {
+  const dataviewMatches = [
+    ...line.matchAll(/\[dependsOn::\s*([^\]]+)\]/gi),
+    ...line.matchAll(/\(dependsOn::\s*([^)]+)\)/gi),
+  ];
+
+  if (
+    dataviewMatches.some((match) => parseMetadataIds(match[1]).includes(hash))
+  ) {
+    return true;
+  }
+
+  return line.includes(hash);
+}
+
+function findTaskLineForSignRemoval(
+  lines: string[],
+  task: BaseTask,
+  type: "stop" | "id",
+  hash: string
+): number {
+  const taskLineIdx = findTaskLineByIdOrText(lines, task.id, task.text);
+  if (taskLineIdx !== -1) return taskLineIdx;
+
+  if (type === "id") {
+    return lines.findIndex(
+      (line) => line.includes(hash) && line.toLowerCase().includes("id::")
+    );
+  }
+
+  return lines.findIndex((line) => lineContainsDependencyHash(line, hash));
+}
+
 export async function updateTaskStatusInVault(
   task: BaseTask,
   newStatus: TaskStatus,
@@ -1014,7 +1054,7 @@ export async function addSignToTaskInFile(
 
   await vault.process(file, (fileContent) => {
     const lines = fileContent.split(/\r?\n/);
-    const taskLineIdx = lines.findIndex((line) => line.includes(task.text));
+    const taskLineIdx = findTaskLineByIdOrText(lines, task.id, task.text);
     if (taskLineIdx === -1) return fileContent;
 
     if (type === "id") {
@@ -1150,7 +1190,7 @@ export async function removeSignFromTaskInFile(
 
   await vault.process(file, (fileContent) => {
     const lines = fileContent.split(/\r?\n/);
-    const taskLineIdx = lines.findIndex((line) => line.includes(task.text));
+    const taskLineIdx = findTaskLineForSignRemoval(lines, task, type, hash);
     if (taskLineIdx === -1) return fileContent;
 
     if (type === "id") {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -797,6 +797,25 @@ describe("removeSignFromTaskInFile", () => {
     expect(content).not.toContain("abc123");
   });
 
+  it("removes consecutive hashes when the task text still has stale metadata", async () => {
+    const vault = makeVault(
+      "- [ ] Test task [dependsOn:: abc123, def456, ghi789]"
+    );
+    const task = makeTask({
+      id: "target1",
+      text: "Test task [dependsOn:: abc123, def456, ghi789]",
+      link: "tasks/test.md",
+    });
+
+    await removeSignFromTaskInFile(vault as any, task, "stop", "abc123");
+    await removeSignFromTaskInFile(vault as any, task, "stop", "def456");
+
+    const content = vault.getFileContent("tasks/test.md");
+    expect(content).toContain("[dependsOn:: ghi789]");
+    expect(content).not.toContain("abc123");
+    expect(content).not.toContain("def456");
+  });
+
   it("removes entire dataview dependsOn block when last hash removed", async () => {
     const vault = makeVault("- [ ] Test task [dependsOn:: abc123]");
     const task = makeTask({ text: "Test task", link: "tasks/test.md" });


### PR DESCRIPTION
## What

When adding or removing dependency signs, the task line was located with a plain `line.includes(task.text)` scan. If a task's `text` still carries stale metadata (e.g. a `[dependsOn:: a, b, c]` block with multiple hashes), that match can land on the wrong line — or fail entirely — silently dropping the edge operation.

This change:
- Locates the line by **ID first** (falling back to text) when adding a sign.
- For sign *removal*, adds `findTaskLineForSignRemoval`, which falls back to locating the line by the dependency **hash** itself (parsing `dependsOn` CSV blocks) when ID/text matching fails.
- Adds a regression test covering consecutive hash removal from a stale multi-hash `dependsOn` block.

## Why

This is the file-matching half of the class of bugs in #165, where a task can lose its ID and subsequent operations match the wrong line.

## Scope

Pure `src/lib/utils.ts` + test change. No UI/React changes. `npm run build`, `jest`, and `eslint` all pass.

---

🧩 Split out of #535 (part 1 of 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)