### PR TITLE
feat: insert a task between two connected tasks from the edge popover

### DIFF
--- a/global.css
+++ b/global.css
@@ -86,11 +86,14 @@ If your plugin does not need CSS, delete this file.
   left: 50%;
   transform: translateX(-50%);
   z-index: 100;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
-.tasks-map-delete-edge-button {
+.tasks-map-delete-edge-button,
+.tasks-map-insert-task-button {
   padding: 10px;
-  background: var(--tasks-map-color-red);
   color: var(--tasks-map-color-white);
   border: none;
   border-radius: 6px;
@@ -98,8 +101,20 @@ If your plugin does not need CSS, delete this file.
   cursor: pointer;
 }
 
+.tasks-map-delete-edge-button {
+  background: var(--tasks-map-color-red);
+}
+
 .tasks-map-delete-edge-button:hover {
   background: var(--tasks-map-color-red-hover, #c53030);
+}
+
+.tasks-map-insert-task-button {
+  background: var(--interactive-accent);
+}
+
+.tasks-map-insert-task-button:hover {
+  background: var(--interactive-accent-hover);
 }
 
 /* Link Button Styles */

--- a/src/components/delete-edge-button.tsx
+++ b/src/components/delete-edge-button.tsx
@@ -1,12 +1,21 @@
+import { t } from "../i18n";
+
 interface DeleteEdgeButtonProps {
   onDelete: () => void;
+  onInsertTask: () => void;
 }
 
-export const DeleteEdgeButton = ({ onDelete }: DeleteEdgeButtonProps) => {
+export const DeleteEdgeButton = ({
+  onDelete,
+  onInsertTask,
+}: DeleteEdgeButtonProps) => {
   return (
     <div className="tasks-map-delete-edge-button-container">
       <button onClick={onDelete} className="tasks-map-delete-edge-button">
-        Delete edge
+        {t("edge_actions.delete_edge")}
+      </button>
+      <button onClick={onInsertTask} className="tasks-map-insert-task-button">
+        {t("edge_actions.insert_task")}
       </button>
     </div>
   );

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -127,8 +127,13 @@
     "done": "Done",
     "canceled": "Canceled"
   },
+  "edge_actions": {
+    "delete_edge": "Delete edge",
+    "insert_task": "Insert task"
+  },
   "errors": {
-    "cannot_create_edges_different_types": "Cannot create edges between different task types (dataview and note-based tasks). Both tasks must be of the same type."
+    "cannot_create_edges_different_types": "Cannot create edges between different task types (dataview and note-based tasks). Both tasks must be of the same type.",
+    "cannot_insert_task_between_non_dataview": "Insert task between edges is only supported for Dataview tasks."
   },
   "notices": {
     "project_assigned": "Added to project: {{projectName}}",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -127,8 +127,13 @@
     "done": "Voltooid",
     "canceled": "Geannuleerd"
   },
+  "edge_actions": {
+    "delete_edge": "Verbinding verwijderen",
+    "insert_task": "Taak invoegen"
+  },
   "errors": {
-    "cannot_create_edges_different_types": "Kan geen verbindingen maken tussen verschillende taaktypes (dataview en notitie-gebaseerde taken). Beide taken moeten van hetzelfde type zijn."
+    "cannot_create_edges_different_types": "Kan geen verbindingen maken tussen verschillende taaktypes (dataview en notitie-gebaseerde taken). Beide taken moeten van hetzelfde type zijn.",
+    "cannot_insert_task_between_non_dataview": "Een taak invoegen tussen verbindingen wordt alleen ondersteund voor Dataview-taken."
   },
   "notices": {
     "project_assigned": "Toegevoegd aan project: {{projectName}}",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -127,8 +127,13 @@
     "done": "完成",
     "canceled": "取消"
   },
+  "edge_actions": {
+    "delete_edge": "删除连线",
+    "insert_task": "插入任务"
+  },
   "errors": {
-    "cannot_create_edges_different_types": "无法在不同任务类型（dataview 和基于笔记的任务）之间创建连接。两个任务必须是相同类型。"
+    "cannot_create_edges_different_types": "无法在不同任务类型（dataview 和基于笔记的任务）之间创建连接。两个任务必须是相同类型。",
+    "cannot_insert_task_between_non_dataview": "仅 Dataview 任务支持在连线之间插入任务。"
   },
   "notices": {
     "project_assigned": "已添加到项目：{{projectName}}",

--- a/src/views/TaskMapGraphView.tsx
+++ b/src/views/TaskMapGraphView.tsx
@@ -513,6 +513,115 @@ export default function TaskMapGraphView({
     updateTaskIncomingLinks,
   ]);
 
+  const onInsertTaskBetweenSelectedEdge = useCallback(async () => {
+    const selected = getSelectedEdgeTasks();
+    if (!selected || !vault) return;
+
+    const { sourceTask, targetTask } = selected;
+    if (sourceTask.type !== "dataview" || targetTask.type !== "dataview") {
+      new Notice(t("errors.cannot_insert_task_between_non_dataview"), 5000);
+      return;
+    }
+
+    const tasksApi = getTasksApi(app);
+    if (!tasksApi) {
+      console.error("Tasks plugin not found or API not available");
+      return;
+    }
+
+    const taskLine = await tasksApi.createTaskLineModal();
+    if (!taskLine?.trim()) {
+      return;
+    }
+
+    const newTask = parseTaskLine(taskLine, sourceTask.link);
+    if (!newTask || newTask.type !== sourceTask.type) {
+      return;
+    }
+
+    let newTaskWritten = false;
+    let oldLinkRemoved = false;
+
+    try {
+      await addTaskLineToVault(sourceTask, taskLine, app, "after");
+      newTaskWritten = true;
+
+      await addSignToTaskInFile(
+        vault,
+        newTask,
+        "id",
+        newTask.id,
+        settings.linkingStyle
+      );
+      await removeLinkSignsBetweenTasks(vault, targetTask, sourceTask.id);
+      oldLinkRemoved = true;
+      await addLinkSignsBetweenTasks(
+        vault,
+        sourceTask,
+        newTask,
+        settings.linkingStyle
+      );
+      await addLinkSignsBetweenTasks(
+        vault,
+        newTask,
+        targetTask,
+        settings.linkingStyle
+      );
+
+      skipFitViewRef.current = true;
+      setNewlyCreatedTaskIds((prevTaskIds) =>
+        new Set(prevTaskIds).add(newTask.id)
+      );
+      setTasks((prevTasks) => {
+        const taskToAdd = createUpdatedTask(newTask, [
+          ...new Set([...newTask.incomingLinks, sourceTask.id]),
+        ]);
+
+        return [
+          ...prevTasks.map((task) => {
+            if (task.id !== targetTask.id) return task;
+
+            const nextIncomingLinks = task.incomingLinks.filter(
+              (id) => id !== sourceTask.id
+            );
+
+            return createUpdatedTask(task, [
+              ...new Set([...nextIncomingLinks, newTask.id]),
+            ]);
+          }),
+          taskToAdd,
+        ];
+      });
+      setSelectedEdge(null);
+    } catch (error) {
+      console.error("Failed to insert task between edge:", error);
+
+      try {
+        await removeLinkSignsBetweenTasks(vault, targetTask, newTask.id);
+        await removeLinkSignsBetweenTasks(vault, newTask, sourceTask.id);
+        if (oldLinkRemoved) {
+          await addLinkSignsBetweenTasks(
+            vault,
+            sourceTask,
+            targetTask,
+            settings.linkingStyle
+          );
+        }
+        if (newTaskWritten) {
+          await deleteTaskFromVault(newTask, app);
+        }
+      } catch (rollbackError) {
+        console.error("Failed to rollback inserted task:", rollbackError);
+      }
+    }
+  }, [
+    app,
+    createUpdatedTask,
+    getSelectedEdgeTasks,
+    settings.linkingStyle,
+    vault,
+  ]);
+
   const onConnect = useCallback(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ReactFlow Connection type is not exported
     async (params: any) => {
@@ -1114,7 +1223,10 @@ export default function TaskMapGraphView({
           )}
         </ReactFlow>
         {selectedEdge && (
-          <DeleteEdgeButton onDelete={() => void onDeleteSelectedEdge()} />
+          <DeleteEdgeButton
+            onDelete={() => void onDeleteSelectedEdge()}
+            onInsertTask={() => void onInsertTaskBetweenSelectedEdge()}
+          />
         )}
       </div>
     </TagsContext.Provider>


### PR DESCRIPTION
> ⚠️ **Stacked on #551** (`feat/optimistic-canvas-editing`). This PR targets that branch, not `main` — review/merge #551 first, then this will retarget to `main`. The diff shown here is only the insert-task delta.

## What

Adds an **"Insert task"** button next to "Delete edge" in the edge popover. For an edge between two **Dataview** tasks it:

1. Opens the Tasks plugin creation modal.
2. Writes the new task and gives it an ID.
3. Rewires `source → new → target`, removing the old `source → target` link.
4. Updates canvas state optimistically (reusing the helpers from #551), so the inserted node and rewired edges appear without a reload.

If the vault operations fail partway, it **rolls back** the writes. Edges between non-Dataview tasks show an explanatory notice instead.

## Why

A common graph edit — splicing a step into an existing dependency chain — currently requires manual creation + rewiring. Relates to #82 (create tasks on edge drag), in the same "create tasks from edge interactions" space.

## Scope & test

`delete-edge-button.tsx` (new button), `TaskMapGraphView.tsx` (`onInsertTaskBetweenSelectedEdge`), i18n (`edge_actions` + insert error, en/nl/zh-CN), CSS. `npm run build`, `jest` (299 passing), `eslint` (0 errors), `stylelint`, `prettier` all pass.

---

🧩 Split out of #535 (part 5 of 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)