### PR TITLE
chore(deps): pin React to v18 so Renovate stops proposing v19

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,11 @@
 			"allowedVersions": "<2.0.0",
 			"description": "Pin dagre to v1.x - v2 has bundling issues with external graphlib dependency"
 		},
+		{
+			"matchPackageNames": ["react", "react-dom", "@types/react", "@types/react-dom"],
+			"allowedVersions": "<19",
+			"description": "Pin React to v18 - v19's bundle trips Obsidian's obfuscation scanner (see #442); we use no v19-specific APIs"
+		},
         {
             "matchUpdateTypes": ["major"],
             "automerge": false,


### PR DESCRIPTION
## Why

React 19's compiled bundle trips Obsidian's plugin scanner (obfuscation / arbitrary-code-execution warning). We use no v19-specific APIs, and React 18 still receives security updates, so the project deliberately stays on v18 — see #442 ("fix: remove unintended obfuscation"), which downgraded us back to 18.

Since then Renovate has kept re-raising the upgrade (#563, #564, #565, previously #444 and #454) because closing a branch only suppresses that one branch, not future re-proposals. I've closed the current three with a pointer to #442.

## What

Adds a Renovate `packageRule` capping `react`, `react-dom`, `@types/react`, and `@types/react-dom` at `<19`, mirroring the existing `@dagrejs/dagre` pin. This lets 18.x minor/patch updates flow normally while preventing the v19 major from being re-proposed.

Validated with `renovate-config-validator` → "Config validated successfully."

🤖 Generated with [Claude Code](https://claude.com/claude-code)