### PR TITLE
refactor: remove all @typescript-eslint/no-explicit-any disables

### DIFF
--- a/src/components/tag-input.tsx
+++ b/src/components/tag-input.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useEffect } from "react";
 import CreatableSelect from "react-select/creatable";
+import { SelectInstance } from "react-select";
 
 interface TagInputProps {
   allTags: string[];
@@ -18,7 +19,7 @@ export function TagInput({
   onCancel,
   hasError = false,
 }: TagInputProps) {
-  const selectRef = useRef<any>(null); // eslint-disable-line @typescript-eslint/no-explicit-any -- react-select ref type is not exported
+  const selectRef = useRef<SelectInstance<TagOption> | null>(null);
   const hasSelectedRef = useRef(false);
   const [inputValue, setInputValue] = React.useState("");
   const [hasSpaceError, setHasSpaceError] = React.useState(false);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,7 +1,15 @@
 // Task utility functions - refactored to use OOP with polymorphism
 import dagre from "@dagrejs/dagre";
-import { App, TFile, Vault } from "obsidian";
+import {
+  App,
+  TFile,
+  TAbstractFile,
+  Vault,
+  CachedMetadata,
+  FrontMatterCache,
+} from "obsidian";
 import { TaskStatus, TaskNode, TaskEdge, RawTask } from "src/types/task";
+import { AppWithPlugins } from "src/types/obsidian-internals";
 import { BaseTask, TaskInsertPosition } from "src/types/base-task";
 import { NODEHEIGHT, NODEWIDTH } from "src/components/task-node";
 import { TaskFactory } from "./task-factory";
@@ -212,8 +220,9 @@ interface TasksApiV1 {
 }
 
 export function getTasksApi(app: App): TasksApiV1 | null {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Obsidian App type does not expose plugins property
-  const tasksPlugin = (app as any).plugins?.plugins?.["obsidian-tasks-plugin"];
+  const tasksPlugin = (app as AppWithPlugins).plugins?.plugins?.[
+    "obsidian-tasks-plugin"
+  ];
 
   if (!tasksPlugin?.apiV1) {
     return null;
@@ -1430,9 +1439,7 @@ export async function removeSignFromTaskInFile(
   });
 }
 
-// TODO: Improve typing for app parameter
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Obsidian App type does not expose plugins property
-export function getAllTasks(app: any): BaseTask[] {
+export function getAllTasks(app: App): BaseTask[] {
   // Central function to gather tasks from all available sources
   const allTasks: BaseTask[] = [];
 
@@ -1445,13 +1452,13 @@ export function getAllTasks(app: any): BaseTask[] {
   return allTasks;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Obsidian App type does not expose plugins property
-export function getAllDataviewTasks(app: any): BaseTask[] {
+export function getAllDataviewTasks(app: App): BaseTask[] {
   let tasks: RawTask[] = [];
 
-  // plugins exists, just not on the Obsidian App API?:
+  // `plugins` exists at runtime, it is just not on the public Obsidian App API:
   //     https://blacksmithgu.github.io/obsidian-dataview/api/intro/#plugin-access
-  const dataviewApi = app.plugins!.plugins?.["dataview"]?.api;
+  const dataviewApi = (app as AppWithPlugins).plugins?.plugins?.["dataview"]
+    ?.api;
   if (dataviewApi && dataviewApi.pages) {
     const pages = dataviewApi.pages();
     for (const page of pages) {
@@ -1467,8 +1474,7 @@ export function getAllDataviewTasks(app: any): BaseTask[] {
   return parsedTasks.filter((task) => !factory.isEmptyTask(task));
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Obsidian App type does not expose plugins property
-export function getNoteTasks(app: any): BaseTask[] {
+export function getNoteTasks(app: App): BaseTask[] {
   const tasks: BaseTask[] = [];
   const vault = app.vault;
   const metadataCache = app.metadataCache;
@@ -1528,9 +1534,12 @@ function normalizeNotePriority(priority: string): string {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Obsidian App type does not expose plugins property
-function parseTaskNote(file: any, cache: any, app: any): BaseTask | null {
-  const frontmatter = cache.frontmatter || {};
+function parseTaskNote(
+  file: TFile,
+  cache: CachedMetadata,
+  app: App
+): BaseTask | null {
+  const frontmatter: FrontMatterCache = cache.frontmatter || {};
   const factory = new TaskFactory();
 
   // Extract task properties from frontmatter
@@ -1613,8 +1622,7 @@ function parseTaskNote(file: any, cache: any, app: any): BaseTask | null {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Obsidian App type does not expose plugins property
-function parseBlockedByLinks(blockedBy: any, app: any): string[] {
+function parseBlockedByLinks(blockedBy: unknown, app: App): string[] {
   const links: string[] = [];
   const vault = app.vault;
 
@@ -1663,12 +1671,12 @@ function parseBlockedByLinks(blockedBy: any, app: any): string[] {
       }
 
       // Try to find the file by name and get its path
-      let file = null;
+      let file: TAbstractFile | null = null;
       try {
         file = vault.getAbstractFileByPath(pageName + ".md");
         if (!file) {
           const markdownFiles = vault.getMarkdownFiles();
-          file = markdownFiles.find((f: any) => f.basename === pageName); // eslint-disable-line @typescript-eslint/no-explicit-any -- Obsidian TFile type not available in this context
+          file = markdownFiles.find((f) => f.basename === pageName) ?? null;
         }
       } catch {
         continue;
@@ -1963,9 +1971,8 @@ function layoutNodesWithDagreInternal(
  * @param app Obsidian App instance
  * @returns object with isInstalled, isEnabled, and getMessage() function
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Obsidian App type does not expose plugins property
-export function checkDataviewPlugin(app: any) {
-  const plugins = app.plugins;
+export function checkDataviewPlugin(app: App) {
+  const plugins = (app as AppWithPlugins).plugins;
 
   // Check if plugin is installed (available in plugins list)
   const installedPlugins = plugins?.manifests || {};

--- a/src/types/obsidian-internals.ts
+++ b/src/types/obsidian-internals.ts
@@ -1,0 +1,44 @@
+import type { App } from "obsidian";
+import type { RawTask } from "src/types/task";
+
+/**
+ * Obsidian's public `App` type intentionally does not expose the internal
+ * plugin registry (`app.plugins`). These interfaces describe only the small
+ * slice of that undocumented surface this plugin actually reads, so we can
+ * access it in a type-safe way without resorting to `any`.
+ *
+ * Registry access is documented for Dataview here:
+ * https://blacksmithgu.github.io/obsidian-dataview/api/intro/#plugin-access
+ */
+
+export interface DataviewPageFile {
+  tasks?: { values?: RawTask[] };
+}
+
+export interface DataviewPage {
+  file?: DataviewPageFile;
+}
+
+export interface DataviewApi {
+  pages(_source?: string): Iterable<DataviewPage>;
+}
+
+export interface InternalPlugin {
+  /** Obsidian Tasks plugin API (typed by the caller). */
+  apiV1?: unknown;
+  /** Dataview query API. */
+  api?: DataviewApi;
+  /** Dataview index status. */
+  index?: { initialized?: boolean };
+}
+
+export interface PluginRegistry {
+  plugins?: Record<string, InternalPlugin | undefined>;
+  manifests?: Record<string, unknown>;
+  enabledPlugins?: Set<string>;
+}
+
+/** `App` augmented with the undocumented plugin registry. */
+export interface AppWithPlugins extends App {
+  plugins: PluginRegistry;
+}

--- a/src/views/TaskMapGraphView.tsx
+++ b/src/views/TaskMapGraphView.tsx
@@ -7,8 +7,12 @@ import ReactFlow, {
   useReactFlow,
   type NodeDragHandler,
   type SelectionDragHandler,
+  type EdgeMouseHandler,
+  type OnConnect,
+  type OnConnectStart,
 } from "reactflow";
-import { Notice } from "obsidian";
+import { Notice, Events } from "obsidian";
+import { AppWithPlugins } from "src/types/obsidian-internals";
 import { useApp } from "src/hooks/hooks";
 import {
   addLinkSignsBetweenTasks,
@@ -287,16 +291,18 @@ export default function TaskMapGraphView({
 
   useEffect(() => {
     // Get the Dataview plugin to check index status
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Obsidian App type does not expose plugins property
-    const dataviewPlugin = (app as any).plugins?.plugins?.["dataview"];
+    const dataviewPlugin = (app as AppWithPlugins).plugins?.plugins?.[
+      "dataview"
+    ];
 
     // Check if Dataview index is already initialized
     if (dataviewPlugin?.index?.initialized) {
       // Index already ready, load tasks immediately
       reloadTasks();
     } else {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Obsidian App type does not expose metadataCache events
-      const metadataCache = (app as any).metadataCache;
+      // `dataview:index-ready` is a custom event, so access it through the
+      // generic `Events` base type rather than MetadataCache's typed overloads.
+      const metadataCache: Events = app.metadataCache;
       const eventRef = metadataCache.on("dataview:index-ready", () => {
         reloadTasks();
       });
@@ -435,9 +441,8 @@ export default function TaskMapGraphView({
     [tasks]
   );
 
-  const onEdgeClick = useCallback(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ReactFlow event/edge types lack exported union
-    (event: any, edge: any) => {
+  const onEdgeClick = useCallback<EdgeMouseHandler>(
+    (event, edge) => {
       event.stopPropagation();
       setSelectedEdge(edge.id);
     },
@@ -622,9 +627,8 @@ export default function TaskMapGraphView({
     vault,
   ]);
 
-  const onConnect = useCallback(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ReactFlow Connection type is not exported
-    async (params: any) => {
+  const onConnect = useCallback<OnConnect>(
+    async (params) => {
       // Reset so onConnectEnd (which fires after onConnect) does not
       // misinterpret this as a canvas-drop and open the create modal.
       connectStartRef.current = null;
@@ -780,21 +784,17 @@ export default function TaskMapGraphView({
     [app, createUpdatedTask, settings.linkingStyle, vault]
   );
 
-  const onConnectStart = useCallback(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- ReactFlow OnConnectStartParams type is not exported
-    (_event: any, params: any) => {
-      if (!params?.nodeId || !params?.handleType) {
-        connectStartRef.current = null;
-        return;
-      }
+  const onConnectStart = useCallback<OnConnectStart>((_event, params) => {
+    if (!params?.nodeId || !params?.handleType) {
+      connectStartRef.current = null;
+      return;
+    }
 
-      connectStartRef.current = {
-        nodeId: params.nodeId,
-        handleType: params.handleType,
-      };
-    },
-    []
-  );
+    connectStartRef.current = {
+      nodeId: params.nodeId,
+      handleType: params.handleType,
+    };
+  }, []);
 
   const onConnectEnd = useCallback(
     async (event: MouseEvent | TouchEvent) => {


### PR DESCRIPTION
## Why

The Obsidian plugin reviewer flags `// eslint-disable ... no-explicit-any` comments as a quality/risk signal — a suppressed lint rule reads as "hiding a problem," which was marking the plugin as low quality. This removes every such disable in `src/` by giving the values real types instead of suppressing the rule.

## What

- **New `src/types/obsidian-internals.ts`** — typed interfaces for the undocumented `app.plugins` registry (deliberately omitted from Obsidian's public `App` type) and the slice of the Dataview API we read. Access now goes through `app as AppWithPlugins` instead of `app as any`.
- **`src/lib/utils.ts`** — retyped function params to `App` / `TFile` / `CachedMetadata` / `FrontMatterCache` / `TAbstractFile` / `unknown`; `.find()` now infers `TFile` from `getMarkdownFiles()`.
- **`src/views/TaskMapGraphView.tsx`** — the ReactFlow handlers use their exported types (`EdgeMouseHandler`, `OnConnect`, `OnConnectStart` via `useCallback<T>`); the custom `dataview:index-ready` event is registered by upcasting `app.metadataCache` to the `Events` base class (whose `on(name: string, …)` accepts custom event names — no cast needed).
- **`src/components/tag-input.tsx`** — the react-select ref uses the exported `SelectInstance<TagOption>` type.

## Verification

- `tsc -noEmit` (build typecheck): passes
- `npm run lint`: 0 errors
- `jest`: 304 tests pass
- `grep -rn no-explicit-any src/`: none remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)